### PR TITLE
feat: v0.7.0 — caching, dark mode, tags, composites, bulk ops, maintenance notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to StatusOwl are documented here. This project follows [Sema
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-03-13
+
+### Added
+- **HTTP Response Caching** — ETag/Last-Modified middleware with in-memory LRU cache (500 entries, configurable TTL), conditional 304 responses, automatic invalidation on mutations, cache stats endpoint (#74)
+- **Maintenance Notification Automation** — Pre-maintenance alerts (1h before), start/end notifications via email/webhook/SSE, duplicate prevention with tracking table, 5-minute scan interval (#75)
+- **Dark Mode + Theme Engine** — CSS custom properties for all colors, light/dark themes, OS preference detection, localStorage persistence, theme toggle button, server-side theme config API (#76)
+- **Service Tags** — Tag CRUD with colors, service-tag associations, AND/OR tag-based filtering, cascade delete, 10 predefined default colors (#77)
+- **Composite Services** — Virtual services with aggregated status from children: worst-case, majority, and weighted derivation rules, BFS cycle detection, nested composites (#78)
+- **Bulk Operations API** — Batch create/update/delete services (up to 100 per request), atomic transaction mode with rollback, partial mode with per-item results, Zod validation, audit logging (#79)
+- Database migrations #14 (maintenance_notifications), #15 (tags + service_tags), #16 (composite_children)
+- `composite` check type for virtual services
+- API routes: `/api/bulk/services/{create,update,delete}`, `/api/tags`, `/api/services/:id/tags`, `/api/theme`, theme config CRUD
+- 834 tests across 40 modules (228 new tests)
+
 ## [0.6.0] — 2026-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ StatusOwl monitors HTTP endpoints, tracks incidents, displays uptime history, an
 - **Health Score + SLA Tracking** — Weighted health score calculation, per-service SLA targets with compliance monitoring
 - **Uptime History Calendar** — GitHub-style contribution calendar showing daily uptime levels
 - **SSE Event Stream** — Server-Sent Events for real-time status page updates with event replay
+- **HTTP Response Caching** — ETag/Last-Modified middleware with LRU cache, conditional 304 responses, auto-invalidation
+- **Maintenance Notifications** — Automated pre/start/end notifications via email, webhooks, and SSE
+- **Dark Mode + Themes** — Light/dark themes with OS detection, toggle button, server-side config API
+- **Service Tags** — Tag-based service organization with AND/OR filtering and color labels
+- **Composite Services** — Virtual services with aggregated status (worst-case, majority, weighted rules)
+- **Bulk Operations** — Batch create/update/delete up to 100 services with atomic or partial mode
 - **Paginated API** — Cursor-based pagination with filtering on `/api/v2/` endpoints
 - **RESTful API** — Full CRUD for services, groups, incidents, maintenance windows, alert policies, and auth
 - **Graceful Shutdown** — Proper signal handling, scheduler cleanup, database close

--- a/src/api/bulk-operations.ts
+++ b/src/api/bulk-operations.ts
@@ -1,0 +1,333 @@
+/**
+ * StatusOwl — Bulk Operations API
+ *
+ * Batch endpoints for service management: bulk create, update, and delete.
+ * Supports atomic (default) and partial (?mode=partial) execution modes.
+ * Max 100 items per batch request. Zod validation on all items before execution.
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { CreateServiceSchema, ok, err, createChildLogger } from '../core/index.js';
+import type { Result, Service, CreateService } from '../core/index.js';
+import { createService, updateService, deleteService } from '../storage/service-repo.js';
+import { getDb } from '../storage/database.js';
+import { recordAudit } from '../audit/audit-repo.js';
+import { requireAuth } from './auth.js';
+
+const log = createChildLogger('BulkOps');
+
+const MAX_BATCH_SIZE = 100;
+
+// ── Schemas ──
+
+const BulkCreateSchema = z.object({
+  services: z.array(CreateServiceSchema).min(1).max(MAX_BATCH_SIZE),
+});
+
+const BulkUpdateItemSchema = CreateServiceSchema.partial().extend({
+  id: z.string().uuid(),
+});
+
+const BulkUpdateSchema = z.object({
+  updates: z.array(BulkUpdateItemSchema).min(1).max(MAX_BATCH_SIZE),
+});
+
+const BulkDeleteSchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(MAX_BATCH_SIZE),
+});
+
+// ── Types ──
+
+interface BulkItemResult<T> {
+  index: number;
+  ok: boolean;
+  data?: T;
+  error?: { code: string; message: string };
+}
+
+interface BulkResponse<T> {
+  ok: boolean;
+  mode: 'atomic' | 'partial';
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: BulkItemResult<T>[];
+}
+
+/**
+ * Extract error message from a failed Result, throwing if the result failed.
+ * This helper exists because TypeScript's narrowing cannot flow through `throw new Error(result.error.message)`
+ * in a single expression when `result` is a discriminated union.
+ */
+function throwIfFailed<T>(result: Result<T>, prefix: string): asserts result is { ok: true; data: T } {
+  if (result.ok) return;
+  const errResult = result as { ok: false; error: { code: string; message: string } };
+  throw new Error(`${prefix}${errResult.error.message}`);
+}
+
+// ── Handlers ──
+
+/**
+ * Bulk create services.
+ * Atomic mode (default): all succeed or all rollback.
+ * Partial mode (?mode=partial): continue on error, report per-item results.
+ */
+export function bulkCreateServices(
+  services: CreateService[],
+  mode: 'atomic' | 'partial' = 'atomic'
+): Result<BulkResponse<Service>> {
+  const db = getDb();
+  const results: BulkItemResult<Service>[] = [];
+  let succeeded = 0;
+  let failed = 0;
+
+  if (mode === 'atomic') {
+    try {
+      const txn = db.transaction(() => {
+        for (let i = 0; i < services.length; i++) {
+          const result = createService(services[i]);
+          throwIfFailed(result, `Item ${i}: `);
+          recordAudit('service.create', 'service', result.data.id, {
+            detail: `Bulk create: ${result.data.name}`,
+          });
+          results.push({ index: i, ok: true, data: result.data });
+          succeeded++;
+        }
+      });
+      txn();
+      log.info({ count: services.length, mode }, 'Bulk create completed');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      log.error({ error: msg, mode }, 'Bulk create failed (atomic rollback)');
+      return err('BULK_CREATE_FAILED', `Atomic bulk create failed: ${msg}`);
+    }
+  } else {
+    // Partial mode: each item in its own savepoint
+    for (let i = 0; i < services.length; i++) {
+      try {
+        const savepointTxn = db.transaction(() => {
+          const result = createService(services[i]);
+          throwIfFailed(result, '');
+          recordAudit('service.create', 'service', result.data.id, {
+            detail: `Bulk create: ${result.data.name}`,
+          });
+          results.push({ index: i, ok: true, data: result.data });
+          succeeded++;
+        });
+        savepointTxn();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        results.push({ index: i, ok: false, error: { code: 'CREATE_FAILED', message: msg } });
+        failed++;
+      }
+    }
+    log.info({ total: services.length, succeeded, failed, mode }, 'Bulk create completed (partial)');
+  }
+
+  return ok({
+    ok: failed === 0,
+    mode,
+    total: services.length,
+    succeeded,
+    failed,
+    results,
+  });
+}
+
+/**
+ * Bulk update services.
+ * Each update item must include an `id` and any fields to change.
+ */
+export function bulkUpdateServices(
+  updates: Array<{ id: string } & Partial<CreateService>>,
+  mode: 'atomic' | 'partial' = 'atomic'
+): Result<BulkResponse<Service>> {
+  const db = getDb();
+  const results: BulkItemResult<Service>[] = [];
+  let succeeded = 0;
+  let failed = 0;
+
+  if (mode === 'atomic') {
+    try {
+      const txn = db.transaction(() => {
+        for (let i = 0; i < updates.length; i++) {
+          const { id, ...changes } = updates[i];
+          const result = updateService(id, changes);
+          throwIfFailed(result, `Item ${i} (id=${id}): `);
+          recordAudit('service.update', 'service', id, {
+            detail: `Bulk update: ${Object.keys(changes).join(', ')}`,
+          });
+          results.push({ index: i, ok: true, data: result.data });
+          succeeded++;
+        }
+      });
+      txn();
+      log.info({ count: updates.length, mode }, 'Bulk update completed');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      log.error({ error: msg, mode }, 'Bulk update failed (atomic rollback)');
+      return err('BULK_UPDATE_FAILED', `Atomic bulk update failed: ${msg}`);
+    }
+  } else {
+    for (let i = 0; i < updates.length; i++) {
+      try {
+        const savepointTxn = db.transaction(() => {
+          const { id, ...changes } = updates[i];
+          const result = updateService(id, changes);
+          throwIfFailed(result, '');
+          recordAudit('service.update', 'service', id, {
+            detail: `Bulk update: ${Object.keys(changes).join(', ')}`,
+          });
+          results.push({ index: i, ok: true, data: result.data });
+          succeeded++;
+        });
+        savepointTxn();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        results.push({ index: i, ok: false, error: { code: 'UPDATE_FAILED', message: msg } });
+        failed++;
+      }
+    }
+    log.info({ total: updates.length, succeeded, failed, mode }, 'Bulk update completed (partial)');
+  }
+
+  return ok({
+    ok: failed === 0,
+    mode,
+    total: updates.length,
+    succeeded,
+    failed,
+    results,
+  });
+}
+
+/**
+ * Bulk delete services.
+ */
+export function bulkDeleteServices(
+  ids: string[],
+  mode: 'atomic' | 'partial' = 'atomic'
+): Result<BulkResponse<{ id: string }>> {
+  const db = getDb();
+  const results: BulkItemResult<{ id: string }>[] = [];
+  let succeeded = 0;
+  let failed = 0;
+
+  if (mode === 'atomic') {
+    try {
+      const txn = db.transaction(() => {
+        for (let i = 0; i < ids.length; i++) {
+          const result = deleteService(ids[i]);
+          throwIfFailed(result, `Item ${i} (id=${ids[i]}): `);
+          recordAudit('service.delete', 'service', ids[i], {
+            detail: 'Bulk delete',
+          });
+          results.push({ index: i, ok: true, data: { id: ids[i] } });
+          succeeded++;
+        }
+      });
+      txn();
+      log.info({ count: ids.length, mode }, 'Bulk delete completed');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      log.error({ error: msg, mode }, 'Bulk delete failed (atomic rollback)');
+      return err('BULK_DELETE_FAILED', `Atomic bulk delete failed: ${msg}`);
+    }
+  } else {
+    for (let i = 0; i < ids.length; i++) {
+      try {
+        const savepointTxn = db.transaction(() => {
+          const result = deleteService(ids[i]);
+          throwIfFailed(result, '');
+          recordAudit('service.delete', 'service', ids[i], {
+            detail: 'Bulk delete',
+          });
+          results.push({ index: i, ok: true, data: { id: ids[i] } });
+          succeeded++;
+        });
+        savepointTxn();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        results.push({ index: i, ok: false, error: { code: 'DELETE_FAILED', message: msg } });
+        failed++;
+      }
+    }
+    log.info({ total: ids.length, succeeded, failed, mode }, 'Bulk delete completed (partial)');
+  }
+
+  return ok({
+    ok: failed === 0,
+    mode,
+    total: ids.length,
+    succeeded,
+    failed,
+    results,
+  });
+}
+
+// ── Express Route Handlers ──
+
+export const bulkRouter = Router();
+
+bulkRouter.post('/api/bulk/services/create', requireAuth, (req: Request, res: Response) => {
+  const parsed = BulkCreateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: { code: 'VALIDATION', message: parsed.error.message },
+    });
+  }
+
+  const mode = req.query.mode === 'partial' ? 'partial' as const : 'atomic' as const;
+  const result = bulkCreateServices(parsed.data.services, mode);
+
+  if (!result.ok) {
+    return res.status(500).json(result);
+  }
+
+  const statusCode = result.data.failed > 0 ? 207 : 201;
+  res.status(statusCode).json({ ok: true, data: result.data });
+});
+
+bulkRouter.post('/api/bulk/services/update', requireAuth, (req: Request, res: Response) => {
+  const parsed = BulkUpdateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: { code: 'VALIDATION', message: parsed.error.message },
+    });
+  }
+
+  const mode = req.query.mode === 'partial' ? 'partial' as const : 'atomic' as const;
+  // Schema guarantees id is present via .extend({ id: z.string().uuid() })
+  const updates = parsed.data.updates as Array<{ id: string } & Partial<CreateService>>;
+  const result = bulkUpdateServices(updates, mode);
+
+  if (!result.ok) {
+    return res.status(500).json(result);
+  }
+
+  const statusCode = result.data.failed > 0 ? 207 : 200;
+  res.status(statusCode).json({ ok: true, data: result.data });
+});
+
+bulkRouter.post('/api/bulk/services/delete', requireAuth, (req: Request, res: Response) => {
+  const parsed = BulkDeleteSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: { code: 'VALIDATION', message: parsed.error.message },
+    });
+  }
+
+  const mode = req.query.mode === 'partial' ? 'partial' as const : 'atomic' as const;
+  const result = bulkDeleteServices(parsed.data.ids, mode);
+
+  if (!result.ok) {
+    return res.status(500).json(result);
+  }
+
+  const statusCode = result.data.failed > 0 ? 207 : 200;
+  res.status(statusCode).json({ ok: true, data: result.data });
+});

--- a/src/api/cache-middleware.ts
+++ b/src/api/cache-middleware.ts
@@ -1,0 +1,572 @@
+/**
+ * StatusOwl — HTTP Response Cache Middleware
+ *
+ * ETag/Last-Modified conditional caching with in-memory LRU store.
+ * Handles If-None-Match and If-Modified-Since for 304 responses.
+ * Automatically invalidates cache entries on mutation requests.
+ */
+
+import { createHash } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { createChildLogger } from '../core/index.js';
+
+const log = createChildLogger('CacheMiddleware');
+
+// ── Types ──
+
+export interface CacheMiddlewareOptions {
+  /** Maximum number of cached entries (default: 500) */
+  maxEntries?: number;
+  /** Default TTL in seconds (default: 60) */
+  defaultTtlSeconds?: number;
+  /** Cache-Control header value for GET responses (default: 'public, max-age=60') */
+  cacheControl?: string;
+  /** Route prefixes that share an invalidation group, keyed by group name.
+   *  Mutation on any route in a group invalidates all cached entries in that group.
+   *  Example: { services: ['/api/services', '/api/groups'] }
+   */
+  invalidationGroups?: Record<string, string[]>;
+}
+
+interface CacheEntry {
+  etag: string;
+  lastModified: string;
+  body: string;
+  statusCode: number;
+  headers: Record<string, string>;
+  createdAt: number;
+  ttlMs: number;
+  /** Which invalidation groups this entry belongs to */
+  groups: string[];
+}
+
+export interface CacheStats {
+  /** Total entries currently stored */
+  size: number;
+  /** Maximum allowed entries */
+  maxEntries: number;
+  /** Total cache hits (304 returned) */
+  hits: number;
+  /** Total cache misses (full response sent) */
+  misses: number;
+  /** Total entries evicted via LRU */
+  evictions: number;
+  /** Total entries removed via invalidation */
+  invalidations: number;
+  /** Hit rate as a percentage (0-100) */
+  hitRate: number;
+}
+
+// ── LRU Cache Implementation ──
+
+/**
+ * Doubly-linked-list node for LRU ordering.
+ * Most-recently-used at the head, least-recently-used at the tail.
+ */
+interface LruNode {
+  key: string;
+  prev: LruNode | null;
+  next: LruNode | null;
+}
+
+class LruCache {
+  private readonly maxEntries: number;
+  private readonly store = new Map<string, CacheEntry>();
+  private readonly order = new Map<string, LruNode>();
+  private head: LruNode | null = null;
+  private tail: LruNode | null = null;
+
+  /** Running counters for stats */
+  private _hits = 0;
+  private _misses = 0;
+  private _evictions = 0;
+  private _invalidations = 0;
+
+  constructor(maxEntries: number) {
+    this.maxEntries = maxEntries;
+  }
+
+  // ── Public API ──
+
+  get(key: string): CacheEntry | undefined {
+    const entry = this.store.get(key);
+    if (!entry) {
+      this._misses++;
+      return undefined;
+    }
+
+    // Check TTL
+    if (Date.now() - entry.createdAt > entry.ttlMs) {
+      this.delete(key);
+      this._misses++;
+      return undefined;
+    }
+
+    // Promote to head (most recently used)
+    this.promote(key);
+    this._hits++;
+    return entry;
+  }
+
+  set(key: string, entry: CacheEntry): void {
+    // If the key already exists, update in place and promote
+    if (this.store.has(key)) {
+      this.store.set(key, entry);
+      this.promote(key);
+      return;
+    }
+
+    // Evict LRU entries if at capacity
+    while (this.store.size >= this.maxEntries && this.tail) {
+      this.evictTail();
+    }
+
+    // Insert new entry
+    this.store.set(key, entry);
+    this.addToHead(key);
+  }
+
+  delete(key: string): boolean {
+    if (!this.store.has(key)) return false;
+    this.store.delete(key);
+    this.removeNode(key);
+    return true;
+  }
+
+  /**
+   * Invalidate all entries whose keys match the given URL path pattern
+   * or that belong to any of the specified invalidation groups.
+   * Cache keys are stored as "METHOD:/path", so the pattern is matched
+   * against the path portion after the method prefix.
+   */
+  invalidateByPattern(pattern: string, groups: string[] = []): number {
+    let count = 0;
+    const keysToDelete: string[] = [];
+
+    for (const [key, entry] of this.store) {
+      // Extract the URL path from the cache key (strip "METHOD:" prefix)
+      const colonIndex = key.indexOf(':');
+      const keyPath = colonIndex >= 0 ? key.substring(colonIndex + 1) : key;
+
+      // Match by URL prefix
+      if (keyPath.startsWith(pattern)) {
+        keysToDelete.push(key);
+        continue;
+      }
+      // Match by group membership
+      if (groups.length > 0 && entry.groups.some(g => groups.includes(g))) {
+        keysToDelete.push(key);
+      }
+    }
+
+    for (const key of keysToDelete) {
+      this.delete(key);
+      count++;
+    }
+
+    this._invalidations += count;
+    return count;
+  }
+
+  clear(): void {
+    this.store.clear();
+    this.order.clear();
+    this.head = null;
+    this.tail = null;
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+
+  get stats(): {
+    hits: number;
+    misses: number;
+    evictions: number;
+    invalidations: number;
+  } {
+    return {
+      hits: this._hits,
+      misses: this._misses,
+      evictions: this._evictions,
+      invalidations: this._invalidations,
+    };
+  }
+
+  // ── Internal linked-list operations ──
+
+  private addToHead(key: string): void {
+    const node: LruNode = { key, prev: null, next: this.head };
+    if (this.head) {
+      this.head.prev = node;
+    }
+    this.head = node;
+    if (!this.tail) {
+      this.tail = node;
+    }
+    this.order.set(key, node);
+  }
+
+  private removeNode(key: string): void {
+    const node = this.order.get(key);
+    if (!node) return;
+
+    if (node.prev) {
+      node.prev.next = node.next;
+    } else {
+      this.head = node.next;
+    }
+
+    if (node.next) {
+      node.next.prev = node.prev;
+    } else {
+      this.tail = node.prev;
+    }
+
+    this.order.delete(key);
+  }
+
+  private promote(key: string): void {
+    const node = this.order.get(key);
+    if (!node || node === this.head) return;
+    this.removeNode(key);
+    this.addToHead(key);
+  }
+
+  private evictTail(): void {
+    if (!this.tail) return;
+    const evictedKey = this.tail.key;
+    this.delete(evictedKey);
+    this._evictions++;
+  }
+}
+
+// ── Module-level cache instance ──
+
+let cache: LruCache | null = null;
+let cacheOptions: Required<CacheMiddlewareOptions> | null = null;
+
+function getCache(): LruCache {
+  if (!cache) {
+    cache = new LruCache(500);
+    cacheOptions = {
+      maxEntries: 500,
+      defaultTtlSeconds: 60,
+      cacheControl: 'public, max-age=60',
+      invalidationGroups: {},
+    };
+  }
+  return cache;
+}
+
+function getOptions(): Required<CacheMiddlewareOptions> {
+  if (!cacheOptions) {
+    getCache(); // initializes options
+  }
+  return cacheOptions!;
+}
+
+// ── ETag generation ──
+
+/**
+ * Generate a weak ETag from a response body using MD5.
+ * Uses the W/ prefix per RFC 7232 to indicate semantic equivalence.
+ */
+export function generateETag(body: string): string {
+  const hash = createHash('md5').update(body).digest('hex');
+  return `W/"${hash}"`;
+}
+
+// ── Helpers ──
+
+/**
+ * Build a cache key from the request.
+ * Uses method + original URL (includes query string).
+ */
+function buildCacheKey(req: Request): string {
+  return `${req.method}:${req.originalUrl}`;
+}
+
+/**
+ * Determine which invalidation groups a given URL path belongs to.
+ */
+function resolveGroups(path: string, groups: Record<string, string[]>): string[] {
+  const matched: string[] = [];
+  for (const [groupName, prefixes] of Object.entries(groups)) {
+    if (prefixes.some(prefix => path.startsWith(prefix))) {
+      matched.push(groupName);
+    }
+  }
+  return matched;
+}
+
+/**
+ * Find all group names that should be invalidated when a mutation
+ * hits the given path.
+ */
+function findGroupsToInvalidate(path: string, groups: Record<string, string[]>): string[] {
+  return resolveGroups(path, groups);
+}
+
+// ── Middleware factory ──
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/**
+ * Create the HTTP caching middleware.
+ *
+ * For GET/HEAD requests:
+ *   - Checks If-None-Match / If-Modified-Since and returns 304 when valid.
+ *   - Caches the response body, ETag, and Last-Modified for future requests.
+ *
+ * For POST/PATCH/PUT/DELETE requests:
+ *   - Invalidates cached entries that share the same route prefix or
+ *     invalidation group, then passes through without caching.
+ */
+export function cacheMiddleware(
+  options: CacheMiddlewareOptions = {},
+): (req: Request, res: Response, next: NextFunction) => void {
+  const maxEntries = options.maxEntries ?? 500;
+  const defaultTtlSeconds = options.defaultTtlSeconds ?? 60;
+  const cacheControl = options.cacheControl ?? 'public, max-age=60';
+  const invalidationGroups = options.invalidationGroups ?? {};
+
+  // Initialize (or re-initialize) the module-level cache
+  cache = new LruCache(maxEntries);
+  cacheOptions = {
+    maxEntries,
+    defaultTtlSeconds,
+    cacheControl,
+    invalidationGroups,
+  };
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const lru = getCache();
+
+    // ── Mutation: invalidate and pass through ──
+    if (MUTATION_METHODS.has(req.method)) {
+      const basePath = extractBasePath(req.originalUrl);
+      const groups = findGroupsToInvalidate(basePath, invalidationGroups);
+      const count = lru.invalidateByPattern(basePath, groups);
+      if (count > 0) {
+        log.debug({ path: basePath, count }, 'Cache invalidated on mutation');
+      }
+      next();
+      return;
+    }
+
+    // ── Only cache GET requests ──
+    if (req.method !== 'GET') {
+      next();
+      return;
+    }
+
+    const cacheKey = buildCacheKey(req);
+    const cached = lru.get(cacheKey);
+
+    if (cached) {
+      // ── Conditional: If-None-Match ──
+      const ifNoneMatch = req.headers['if-none-match'];
+      if (ifNoneMatch && ifNoneMatch === cached.etag) {
+        res.status(304).end();
+        return;
+      }
+
+      // ── Conditional: If-Modified-Since ──
+      const ifModifiedSince = req.headers['if-modified-since'];
+      if (ifModifiedSince) {
+        const clientDate = new Date(ifModifiedSince).getTime();
+        const serverDate = new Date(cached.lastModified).getTime();
+        if (!isNaN(clientDate) && !isNaN(serverDate) && serverDate <= clientDate) {
+          res.status(304).end();
+          return;
+        }
+      }
+
+      // ── Cache hit: serve from cache ──
+      for (const [header, value] of Object.entries(cached.headers)) {
+        res.setHeader(header, value);
+      }
+      res.setHeader('ETag', cached.etag);
+      res.setHeader('Last-Modified', cached.lastModified);
+      res.setHeader('Cache-Control', cacheControl);
+      res.setHeader('X-Cache', 'HIT');
+      res.status(cached.statusCode).send(cached.body);
+      return;
+    }
+
+    // ── Cache miss: intercept the response to capture it ──
+    const originalJson = res.json.bind(res);
+    const originalSend = res.send.bind(res);
+
+    const captureAndCache = (body: string, statusCode: number): void => {
+      // Only cache successful responses (2xx)
+      if (statusCode < 200 || statusCode >= 300) return;
+
+      const etag = generateETag(body);
+      const lastModified = new Date().toUTCString();
+      const basePath = extractBasePath(req.originalUrl);
+      const groups = resolveGroups(basePath, invalidationGroups);
+
+      const entry: CacheEntry = {
+        etag,
+        lastModified,
+        body,
+        statusCode,
+        headers: {
+          'Content-Type': res.getHeader('content-type') as string || 'application/json',
+        },
+        createdAt: Date.now(),
+        ttlMs: defaultTtlSeconds * 1000,
+        groups,
+      };
+
+      lru.set(cacheKey, entry);
+
+      // Set cache headers on the outgoing response
+      res.setHeader('ETag', etag);
+      res.setHeader('Last-Modified', lastModified);
+      res.setHeader('Cache-Control', cacheControl);
+      res.setHeader('X-Cache', 'MISS');
+    };
+
+    // Override res.json to capture JSON responses
+    res.json = function cacheInterceptJson(data: unknown): Response {
+      const bodyStr = JSON.stringify(data);
+      captureAndCache(bodyStr, res.statusCode);
+      return originalJson(data);
+    };
+
+    // Override res.send to capture string/Buffer responses
+    res.send = function cacheInterceptSend(data: unknown): Response {
+      if (typeof data === 'string') {
+        captureAndCache(data, res.statusCode);
+      } else if (Buffer.isBuffer(data)) {
+        captureAndCache(data.toString('utf-8'), res.statusCode);
+      }
+      return originalSend(data);
+    };
+
+    next();
+  };
+}
+
+// ── Public utilities ──
+
+/**
+ * Invalidate all cache entries whose keys match the given pattern (prefix).
+ * Also invalidates entries in any matching invalidation group.
+ *
+ * @param pattern - URL prefix to match (e.g. '/api/services')
+ * @returns Number of entries invalidated
+ */
+export function invalidateCache(pattern: string): number {
+  const lru = getCache();
+  const opts = getOptions();
+  const groups = findGroupsToInvalidate(pattern, opts.invalidationGroups);
+  const count = lru.invalidateByPattern(pattern, groups);
+  if (count > 0) {
+    log.debug({ pattern, count }, 'Cache manually invalidated');
+  }
+  return count;
+}
+
+/**
+ * Get current cache statistics.
+ */
+export function getCacheStats(): CacheStats {
+  const lru = getCache();
+  const opts = getOptions();
+  const { hits, misses, evictions, invalidations } = lru.stats;
+  const total = hits + misses;
+
+  return {
+    size: lru.size,
+    maxEntries: opts.maxEntries,
+    hits,
+    misses,
+    evictions,
+    invalidations,
+    hitRate: total > 0 ? Math.round((hits / total) * 10000) / 100 : 0,
+  };
+}
+
+/**
+ * Reset the cache (primarily for testing).
+ */
+export function resetCache(): void {
+  if (cache) {
+    cache.clear();
+  }
+  cache = null;
+  cacheOptions = null;
+}
+
+// ── Internal helpers ──
+
+/**
+ * Extract the base path from a URL, stripping the query string
+ * and any trailing UUID-like segments for broader invalidation matching.
+ *
+ * Example: '/api/services/abc-123?limit=10' -> '/api/services'
+ */
+function extractBasePath(url: string): string {
+  // Strip query string
+  const pathOnly = url.split('?')[0];
+
+  // Remove trailing path segments that look like UUIDs or IDs
+  // so that a DELETE to /api/services/abc-123 invalidates /api/services/*
+  const segments = pathOnly.split('/').filter(Boolean);
+  const baseSegments: string[] = [];
+
+  for (const segment of segments) {
+    // Stop at segments that look like UUIDs or numeric IDs
+    if (isIdSegment(segment)) {
+      break;
+    }
+    baseSegments.push(segment);
+  }
+
+  return '/' + baseSegments.join('/');
+}
+
+/**
+ * Known API sub-resource segments that are NOT IDs.
+ * These appear after a resource name and represent nested collections/actions,
+ * not individual resource identifiers.
+ */
+const KNOWN_SUB_RESOURCES = new Set([
+  'api', 'v2', 'checks', 'uptime', 'history', 'ssl', 'percentiles',
+  'dependencies', 'dependents', 'downstream', 'incidents', 'update',
+  'alert-policy', 'alert-policies', 'calendar', 'health-score', 'sla',
+  'sla-targets', 'regional-latency', 'deliveries', 'retry', 'events',
+  'stats', 'badge', 'embed', 'widget', 'reports', 'generate',
+  'audit-log', 'subscriptions', 'confirm', 'unsubscribe', 'regions',
+  'maintenance-windows', 'webhooks', 'services', 'groups', 'branding',
+  'status', 'auth', 'register', 'grant', 'introspect', 'revoke', 'rotate',
+]);
+
+/**
+ * Heuristic: does this path segment look like a resource ID?
+ *
+ * Returns true for:
+ *  - UUID format (e.g. '550e8400-e29b-41d4-a716-446655440000')
+ *  - Pure numeric (e.g. '42')
+ *  - Any segment that is NOT a known sub-resource keyword
+ *    (catches short IDs like 'abc-123', 'some-id', etc.)
+ */
+function isIdSegment(segment: string): boolean {
+  // UUID pattern
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(segment)) {
+    return true;
+  }
+  // Pure numeric
+  if (/^\d+$/.test(segment)) {
+    return true;
+  }
+  // If it's not a known sub-resource name, treat it as an ID
+  if (!KNOWN_SUB_RESOURCES.has(segment.toLowerCase())) {
+    return true;
+  }
+  return false;
+}

--- a/src/api/event-stream.ts
+++ b/src/api/event-stream.ts
@@ -20,6 +20,7 @@ export type SseEventType =
   | 'incident.created'
   | 'incident.updated'
   | 'incident.resolved'
+  | 'maintenance.upcoming'
   | 'maintenance.started'
   | 'maintenance.ended'
   | 'check.completed';
@@ -29,6 +30,7 @@ export const SSE_EVENT_TYPES: readonly SseEventType[] = [
   'incident.created',
   'incident.updated',
   'incident.resolved',
+  'maintenance.upcoming',
   'maintenance.started',
   'maintenance.ended',
   'check.completed',

--- a/src/api/theme-config.ts
+++ b/src/api/theme-config.ts
@@ -1,0 +1,164 @@
+/**
+ * StatusOwl — Theme Configuration API
+ *
+ * Provides server-side default theme configuration.
+ * GET  /api/theme — returns current default theme config (public)
+ * PATCH /api/theme — updates default theme config (admin, requires auth)
+ *
+ * Theme preferences are stored in the SQLite config table.
+ * The status page reads these on load to set the initial theme before
+ * the user's localStorage preference takes over.
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { createChildLogger, ok, err } from '../core/index.js';
+import type { Result } from '../core/index.js';
+import { getDb } from '../storage/database.js';
+import { requireAuth } from './auth.js';
+import { recordAudit } from '../audit/index.js';
+
+const log = createChildLogger('ThemeConfig');
+
+// ── Schema ──
+
+const ThemeMode = z.enum(['light', 'dark', 'system']);
+type ThemeMode = z.infer<typeof ThemeMode>;
+
+const ThemeConfigSchema = z.object({
+  defaultTheme: ThemeMode,
+  allowUserToggle: z.boolean(),
+  customLightColors: z.record(z.string()).optional(),
+  customDarkColors: z.record(z.string()).optional(),
+});
+
+type ThemeConfig = z.infer<typeof ThemeConfigSchema>;
+
+const ThemeConfigUpdateSchema = ThemeConfigSchema.partial();
+
+// ── Default values ──
+
+const DEFAULT_THEME_CONFIG: ThemeConfig = {
+  defaultTheme: 'system',
+  allowUserToggle: true,
+  customLightColors: undefined,
+  customDarkColors: undefined,
+};
+
+// ── Config table key ──
+
+const CONFIG_KEY = 'theme_config';
+
+// ── Storage helpers ──
+
+function ensureConfigTable(): void {
+  const db = getDb();
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS config (
+      key   TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )`
+  ).run();
+}
+
+function getThemeConfig(): Result<ThemeConfig> {
+  try {
+    ensureConfigTable();
+    const db = getDb();
+    const row = db.prepare('SELECT value FROM config WHERE key = ?').get(CONFIG_KEY) as
+      | { value: string }
+      | undefined;
+
+    if (!row) {
+      return ok(DEFAULT_THEME_CONFIG);
+    }
+
+    const parsed = ThemeConfigSchema.safeParse(JSON.parse(row.value));
+    if (!parsed.success) {
+      log.warn({ error: parsed.error.message }, 'Invalid theme config in DB, returning defaults');
+      return ok(DEFAULT_THEME_CONFIG);
+    }
+
+    return ok(parsed.data);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to read theme config');
+    return err('DB_ERROR', msg);
+  }
+}
+
+function updateThemeConfig(updates: Partial<ThemeConfig>): Result<ThemeConfig> {
+  try {
+    ensureConfigTable();
+
+    // Read current config
+    const currentResult = getThemeConfig();
+    if (!currentResult.ok) return currentResult;
+
+    const merged: ThemeConfig = {
+      ...currentResult.data,
+      ...updates,
+    };
+
+    // Validate the merged config
+    const parsed = ThemeConfigSchema.safeParse(merged);
+    if (!parsed.success) {
+      return err('VALIDATION', parsed.error.message);
+    }
+
+    const db = getDb();
+    db.prepare(
+      'INSERT INTO config (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value'
+    ).run(CONFIG_KEY, JSON.stringify(parsed.data));
+
+    log.info({ config: parsed.data }, 'Theme config updated');
+    return ok(parsed.data);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to update theme config');
+    return err('DB_ERROR', msg);
+  }
+}
+
+// ── Router ──
+
+export const themeRouter = Router();
+
+/**
+ * GET /api/theme — returns current default theme configuration (public).
+ */
+themeRouter.get('/api/theme', (_req: Request, res: Response) => {
+  const result = getThemeConfig();
+  if (!result.ok) {
+    return res.status(500).json(result);
+  }
+  res.json(result);
+});
+
+/**
+ * PATCH /api/theme — update default theme configuration (admin).
+ */
+themeRouter.patch('/api/theme', requireAuth, (req: Request, res: Response) => {
+  const parsed = ThemeConfigUpdateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: { code: 'VALIDATION', message: parsed.error.message },
+    });
+  }
+
+  const result: Result<ThemeConfig> = updateThemeConfig(parsed.data);
+  if (!result.ok) {
+    const httpStatus = result.error.code === 'VALIDATION' ? 400 : 500;
+    return res.status(httpStatus).json(result);
+  }
+
+  recordAudit('config.update', 'config', CONFIG_KEY, {
+    detail: `Theme config updated: defaultTheme=${result.data.defaultTheme}`,
+  });
+  res.json(result);
+});
+
+// ── Exports for testing ──
+
+export { getThemeConfig, updateThemeConfig, ThemeConfig, ThemeMode, DEFAULT_THEME_CONFIG };

--- a/src/core/contracts.ts
+++ b/src/core/contracts.ts
@@ -58,7 +58,7 @@ export const ServiceSchema = z.object({
   name: z.string().min(1).max(200),
   url: z.string().url(),
   method: z.enum(['GET', 'HEAD', 'POST']).default('GET'),
-  checkType: z.enum(['http', 'tcp', 'dns']).default('http'),
+  checkType: z.enum(['http', 'tcp', 'dns', 'composite']).default('http'),
   expectedStatus: z.coerce.number().default(200),
   checkInterval: z.coerce.number().min(10).max(3600).default(60), // seconds
   timeout: z.coerce.number().min(1).max(60).default(10),           // seconds
@@ -228,6 +228,7 @@ export const AuditActionSchema = z.enum([
   'maintenance.create', 'maintenance.delete',
   'alert_policy.create', 'alert_policy.update', 'alert_policy.delete',
   'auth.register', 'auth.grant', 'auth.revoke',
+  'config.update',
 ]);
 export type AuditAction = z.infer<typeof AuditActionSchema>;
 
@@ -287,6 +288,22 @@ export const CreateSlaTargetSchema = SlaTargetSchema.omit({
   updatedAt: true,
 });
 export type CreateSlaTarget = z.infer<typeof CreateSlaTargetSchema>;
+
+// ── Tag ──
+
+export const TagSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1).max(100),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+  createdAt: z.string().datetime().optional(),
+});
+export type Tag = z.infer<typeof TagSchema>;
+
+export const ServiceTagSchema = z.object({
+  serviceId: z.string().uuid(),
+  tagId: z.string().uuid(),
+});
+export type ServiceTag = z.infer<typeof ServiceTagSchema>;
 
 // ── Health Score ──
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -40,6 +40,8 @@ export type {
   HealthScoreBreakdown,
   HealthScoreWeights,
   SlaCompliance,
+  Tag,
+  ServiceTag,
 } from './contracts.js';
 
 export {
@@ -67,4 +69,6 @@ export {
   SlaTargetSchema,
   CreateSlaTargetSchema,
   EvaluationPeriod,
+  TagSchema,
+  ServiceTagSchema,
 } from './contracts.js';

--- a/src/maintenance/notification-scheduler.ts
+++ b/src/maintenance/notification-scheduler.ts
@@ -1,0 +1,521 @@
+/**
+ * StatusOwl — Maintenance Notification Scheduler
+ *
+ * Scans for upcoming, starting, and ending maintenance windows at regular
+ * intervals and dispatches notifications through all configured channels:
+ * webhooks, email subscribers, and SSE broadcasts.
+ *
+ * Tracks sent notifications in the `maintenance_notifications` DB table
+ * to prevent duplicate sends across scheduler cycles.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { createHmac } from 'node:crypto';
+import { createChildLogger, ok, err, getConfig } from '../core/index.js';
+import type { Result, MaintenanceWindow } from '../core/index.js';
+import { getDb } from '../storage/database.js';
+import { listMaintenanceWindows } from './maintenance-repo.js';
+import { getWebhooksByEvent } from '../notifications/webhook-repo.js';
+import { listSubscriptions } from '../subscriptions/subscription-repo.js';
+import { getEventBus } from '../api/event-stream.js';
+import type { SseEventType } from '../api/event-stream.js';
+
+const log = createChildLogger('MaintenanceNotify');
+
+/** How often the scheduler scans for windows (ms). */
+const SCAN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** How far before a window starts to send the "upcoming" notification (ms). */
+const PRE_NOTIFY_MS = 60 * 60 * 1000; // 1 hour
+
+/** Notification types tracked in the database. */
+type NotificationType = 'upcoming' | 'started' | 'ended';
+
+/** A record from the maintenance_notifications table. */
+interface NotificationRecord {
+  id: string;
+  maintenanceWindowId: string;
+  notificationType: NotificationType;
+  sentAt: string;
+}
+
+/** Timer handle for the running scheduler. */
+let _timer: ReturnType<typeof setInterval> | null = null;
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+/**
+ * Start the periodic maintenance notification scanner.
+ * Runs an immediate check, then repeats every 5 minutes.
+ */
+export function startMaintenanceNotifier(): void {
+  if (_timer) {
+    log.warn('Maintenance notifier already running');
+    return;
+  }
+
+  log.info('Starting maintenance notification scheduler');
+
+  // Run immediately, then on interval
+  void checkMaintenanceWindows();
+
+  _timer = setInterval(() => {
+    void checkMaintenanceWindows();
+  }, SCAN_INTERVAL_MS);
+
+  // Allow the process to exit without waiting for this timer
+  if (_timer.unref) {
+    _timer.unref();
+  }
+}
+
+/**
+ * Stop the maintenance notification scheduler.
+ */
+export function stopMaintenanceNotifier(): void {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+    log.info('Maintenance notification scheduler stopped');
+  }
+}
+
+/**
+ * Perform a single scan of all maintenance windows and send any
+ * pending notifications. This is the core logic invoked by the
+ * scheduler interval, and is also exported for testing.
+ */
+export async function checkMaintenanceWindows(): Promise<void> {
+  try {
+    const windowsResult = listMaintenanceWindows();
+    if (!windowsResult.ok) {
+      log.error({ error: windowsResult.error }, 'Failed to list maintenance windows');
+      return;
+    }
+
+    const now = new Date();
+
+    for (const window of windowsResult.data) {
+      const startAt = new Date(window.startAt);
+      const endAt = new Date(window.endAt);
+      const msUntilStart = startAt.getTime() - now.getTime();
+      const msUntilEnd = endAt.getTime() - now.getTime();
+
+      // 1. Upcoming: within pre-notify window but hasn't started yet
+      if (msUntilStart > 0 && msUntilStart <= PRE_NOTIFY_MS) {
+        await sendNotificationIfNeeded(window, 'upcoming');
+      }
+
+      // 2. Started: start time has passed but end time hasn't
+      if (msUntilStart <= 0 && msUntilEnd > 0) {
+        await sendNotificationIfNeeded(window, 'started');
+      }
+
+      // 3. Ended: end time has passed
+      if (msUntilEnd <= 0) {
+        await sendNotificationIfNeeded(window, 'ended');
+      }
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Maintenance window check failed');
+  }
+}
+
+// ── Notification State Tracking ─────────────────────────────────────────
+
+/**
+ * Check whether a notification has already been sent for a given
+ * window + type combination.
+ */
+export function hasNotificationBeenSent(
+  windowId: string,
+  type: NotificationType,
+): boolean {
+  try {
+    const db = getDb();
+    const row = db.prepare(
+      'SELECT 1 FROM maintenance_notifications WHERE maintenance_window_id = ? AND notification_type = ?',
+    ).get(windowId, type);
+    return row !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record that a notification was sent, preventing future duplicates.
+ */
+export function recordNotificationSent(
+  windowId: string,
+  type: NotificationType,
+): Result<NotificationRecord> {
+  try {
+    const db = getDb();
+    const id = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(`
+      INSERT INTO maintenance_notifications (id, maintenance_window_id, notification_type, sent_at)
+      VALUES (?, ?, ?, ?)
+    `).run(id, windowId, type, now);
+
+    log.info({ windowId, type }, 'Notification recorded');
+    return ok({ id, maintenanceWindowId: windowId, notificationType: type, sentAt: now });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    // Duplicate constraint means it was already sent — not an error
+    if (msg.includes('UNIQUE constraint')) {
+      return err('DUPLICATE', 'Notification already sent');
+    }
+    log.error({ error: msg, windowId, type }, 'Failed to record notification');
+    return err('DB_ERROR', msg);
+  }
+}
+
+/**
+ * Get all notification records for a maintenance window.
+ */
+export function getNotificationsForWindow(
+  windowId: string,
+): Result<NotificationRecord[]> {
+  try {
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT * FROM maintenance_notifications WHERE maintenance_window_id = ? ORDER BY sent_at',
+    ).all(windowId) as Record<string, unknown>[];
+
+    return ok(rows.map(rowToNotificationRecord));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return err('DB_ERROR', msg);
+  }
+}
+
+// ── Internal Dispatch Logic ─────────────────────────────────────────────
+
+/**
+ * Send a notification for a maintenance window if it hasn't been sent yet.
+ * Records the send in the DB to prevent duplicates.
+ */
+async function sendNotificationIfNeeded(
+  window: MaintenanceWindow,
+  type: NotificationType,
+): Promise<void> {
+  if (hasNotificationBeenSent(window.id, type)) {
+    return;
+  }
+
+  log.info(
+    { windowId: window.id, title: window.title, type },
+    'Sending maintenance notification',
+  );
+
+  // Record first (if another cycle fires before dispatch completes, it won't double-send)
+  const recordResult = recordNotificationSent(window.id, type);
+  if (!recordResult.ok) {
+    // DUPLICATE is fine — another cycle beat us to it
+    if (recordResult.error.code === 'DUPLICATE') return;
+    log.error({ error: recordResult.error }, 'Failed to record notification — skipping dispatch');
+    return;
+  }
+
+  const payload = buildPayload(window, type);
+
+  // Dispatch in parallel: SSE, webhooks, email subscribers
+  const dispatches: Array<Promise<void>> = [];
+
+  // 1. SSE broadcast
+  dispatches.push(broadcastSse(type, payload));
+
+  // 2. Webhooks
+  dispatches.push(dispatchWebhooks(type, payload));
+
+  // 3. Email subscribers (log intent — actual email sending depends on SMTP config)
+  dispatches.push(notifySubscribers(window, type));
+
+  await Promise.allSettled(dispatches);
+
+  log.info({ windowId: window.id, type }, 'Maintenance notification dispatched');
+}
+
+/**
+ * Build the notification payload for a maintenance window event.
+ */
+function buildPayload(
+  window: MaintenanceWindow,
+  type: NotificationType,
+): Record<string, unknown> {
+  return {
+    maintenanceWindowId: window.id,
+    serviceId: window.serviceId,
+    title: window.title,
+    startAt: window.startAt,
+    endAt: window.endAt,
+    notificationType: type,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Map a maintenance notification type to the corresponding SSE event type.
+ */
+function mapToSseEvent(type: NotificationType): SseEventType {
+  switch (type) {
+    case 'upcoming':
+      return 'maintenance.upcoming';
+    case 'started':
+      return 'maintenance.started';
+    case 'ended':
+      return 'maintenance.ended';
+  }
+}
+
+/**
+ * Broadcast a maintenance event via SSE to all connected clients.
+ */
+async function broadcastSse(
+  type: NotificationType,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const eventBus = getEventBus();
+    const sseEvent = mapToSseEvent(type);
+    eventBus.broadcast(sseEvent, payload);
+    log.debug({ type, sseEvent }, 'SSE maintenance event broadcast');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg, type }, 'Failed to broadcast SSE maintenance event');
+  }
+}
+
+/**
+ * Dispatch maintenance notifications to all enabled webhooks that
+ * subscribe to the relevant event type. Uses the same delivery
+ * mechanism as incident notifications.
+ */
+async function dispatchWebhooks(
+  type: NotificationType,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    // Map to webhook event types — maintenance events use the SSE event names
+    const eventName = mapToSseEvent(type);
+
+    // Get webhooks — currently the webhook event schema is limited to incident/service events,
+    // so we dispatch to all enabled webhooks for maintenance events
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT * FROM webhooks WHERE enabled = 1',
+    ).all() as Record<string, unknown>[];
+
+    if (rows.length === 0) {
+      log.debug('No enabled webhooks for maintenance notification');
+      return;
+    }
+
+    const config = getConfig();
+
+    for (const row of rows) {
+      const url = row.url as string;
+      const secret = row.secret as string | undefined;
+
+      try {
+        const body = JSON.stringify({ event: eventName, ...payload });
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          'User-Agent': 'StatusOwl/1.0',
+        };
+
+        if (secret) {
+          const signature = createHmac('sha256', secret).update(body).digest('hex');
+          headers['X-StatusOwl-Signature'] = `sha256=${signature}`;
+        }
+
+        const response = await fetch(url, {
+          method: 'POST',
+          headers,
+          body,
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (response.ok) {
+          log.debug({ url, status: response.status }, 'Maintenance webhook delivered');
+        } else {
+          log.warn({ url, status: response.status }, 'Maintenance webhook delivery failed');
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        log.error({ url, error: msg }, 'Maintenance webhook delivery error');
+      }
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to dispatch maintenance webhooks');
+  }
+}
+
+/**
+ * Notify email subscribers about a maintenance window event.
+ * Logs the notification intent — actual email delivery depends on
+ * SMTP configuration being present.
+ */
+async function notifySubscribers(
+  window: MaintenanceWindow,
+  type: NotificationType,
+): Promise<void> {
+  try {
+    const subsResult = listSubscriptions();
+    if (!subsResult.ok) {
+      log.error({ error: subsResult.error }, 'Failed to list subscriptions for maintenance notify');
+      return;
+    }
+
+    const confirmed = subsResult.data.filter((s) => s.confirmed);
+    if (confirmed.length === 0) {
+      log.debug('No confirmed subscribers for maintenance notification');
+      return;
+    }
+
+    const config = getConfig();
+    if (!config.smtpHost || !config.emailFrom) {
+      log.debug({ subscriberCount: confirmed.length }, 'SMTP not configured — skipping email notifications');
+      return;
+    }
+
+    // Import nodemailer dynamically to avoid issues when SMTP isn't configured
+    const nodemailer = await import('nodemailer');
+    const transporter = nodemailer.default.createTransport({
+      host: config.smtpHost,
+      port: config.smtpPort,
+      secure: config.smtpSecure,
+      auth: config.smtpUser ? { user: config.smtpUser, pass: config.smtpPass } : undefined,
+    });
+
+    const typeLabels: Record<NotificationType, string> = {
+      upcoming: 'Upcoming Maintenance',
+      started: 'Maintenance Started',
+      ended: 'Maintenance Completed',
+    };
+
+    const subject = `[StatusOwl] ${typeLabels[type]}: ${window.title}`;
+    const text = formatMaintenanceEmailText(window, type);
+    const html = formatMaintenanceEmailHtml(window, type);
+
+    // Send to each confirmed subscriber (filter by service if they are service-specific)
+    for (const sub of confirmed) {
+      // If subscriber is service-specific, only notify about that service
+      if (sub.serviceId && sub.serviceId !== window.serviceId) {
+        continue;
+      }
+
+      try {
+        await transporter.sendMail({
+          from: config.emailFrom,
+          to: sub.email,
+          subject,
+          text,
+          html,
+        });
+        log.debug({ email: sub.email, type }, 'Maintenance email sent');
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        log.error({ email: sub.email, error: msg }, 'Failed to send maintenance email');
+      }
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to notify subscribers about maintenance');
+  }
+}
+
+// ── Email Formatting ────────────────────────────────────────────────────
+
+function formatMaintenanceEmailText(
+  window: MaintenanceWindow,
+  type: NotificationType,
+): string {
+  const typeLabels: Record<NotificationType, string> = {
+    upcoming: 'UPCOMING MAINTENANCE',
+    started: 'MAINTENANCE STARTED',
+    ended: 'MAINTENANCE COMPLETED',
+  };
+
+  return [
+    `[${typeLabels[type]}] ${window.title}`,
+    '',
+    `Service: ${window.serviceId}`,
+    `Start: ${window.startAt}`,
+    `End: ${window.endAt}`,
+    `Time: ${new Date().toISOString()}`,
+    '',
+    '-- StatusOwl',
+  ].join('\n');
+}
+
+function formatMaintenanceEmailHtml(
+  window: MaintenanceWindow,
+  type: NotificationType,
+): string {
+  const colors: Record<NotificationType, string> = {
+    upcoming: '#ca8a04',
+    started: '#ea580c',
+    ended: '#16a34a',
+  };
+
+  const typeLabels: Record<NotificationType, string> = {
+    upcoming: 'Upcoming Maintenance',
+    started: 'Maintenance Started',
+    ended: 'Maintenance Completed',
+  };
+
+  const color = colors[type];
+
+  return `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:20px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f3f4f6;">
+  <div style="max-width:600px;margin:0 auto;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+    <div style="background:${color};padding:16px 24px;">
+      <h1 style="color:#fff;margin:0;font-size:18px;">${typeLabels[type]}</h1>
+    </div>
+    <div style="padding:24px;">
+      <h2 style="margin:0 0 12px;font-size:20px;color:#111827;">${escapeHtml(window.title)}</h2>
+      <table style="width:100%;border-collapse:collapse;margin-bottom:16px;">
+        <tr>
+          <td style="padding:8px 0;color:#6b7280;font-size:14px;">Window Start</td>
+          <td style="padding:8px 0;font-size:14px;">${window.startAt}</td>
+        </tr>
+        <tr>
+          <td style="padding:8px 0;color:#6b7280;font-size:14px;">Window End</td>
+          <td style="padding:8px 0;font-size:14px;">${window.endAt}</td>
+        </tr>
+      </table>
+    </div>
+    <div style="padding:16px 24px;background:#f9fafb;border-top:1px solid #e5e7eb;font-size:12px;color:#9ca3af;">
+      Sent by StatusOwl
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function rowToNotificationRecord(row: Record<string, unknown>): NotificationRecord {
+  return {
+    id: row.id as string,
+    maintenanceWindowId: row.maintenance_window_id as string,
+    notificationType: row.notification_type as NotificationType,
+    sentAt: row.sent_at as string,
+  };
+}

--- a/src/monitors/composite-service.ts
+++ b/src/monitors/composite-service.ts
@@ -1,0 +1,450 @@
+/**
+ * StatusOwl — Composite Service Engine
+ *
+ * Creates and manages composite services whose status is derived
+ * from their children using configurable derivation rules:
+ *   - worst-case: any child down => composite down
+ *   - majority: status = most common among children (>50%)
+ *   - weighted: status weighted by per-child weight values
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDb } from '../storage/database.js';
+import { getService, updateServiceStatus } from '../storage/service-repo.js';
+import { ok, err, createChildLogger } from '../core/index.js';
+import type { Result, Service, ServiceStatus } from '../core/index.js';
+
+const log = createChildLogger('CompositeService');
+
+// ── Types ──
+
+export type DerivationRule = 'worst-case' | 'majority' | 'weighted';
+
+export interface CompositeChild {
+  compositeId: string;
+  childId: string;
+  weight: number;
+  derivationRule: DerivationRule;
+  createdAt: string;
+}
+
+// ── Severity ranking (higher = worse) ──
+
+const STATUS_SEVERITY: Record<ServiceStatus, number> = {
+  operational: 0,
+  degraded: 1,
+  partial_outage: 2,
+  major_outage: 3,
+  maintenance: 4,
+  unknown: 5,
+};
+
+const SEVERITY_TO_STATUS: ServiceStatus[] = [
+  'operational',
+  'degraded',
+  'partial_outage',
+  'major_outage',
+  'maintenance',
+  'unknown',
+];
+
+// ── Row mapping ──
+
+function rowToChild(row: Record<string, unknown>): CompositeChild {
+  return {
+    compositeId: row.composite_id as string,
+    childId: row.child_id as string,
+    weight: row.weight as number,
+    derivationRule: row.derivation_rule as DerivationRule,
+    createdAt: row.created_at as string,
+  };
+}
+
+// ── Derivation rule lookup ──
+
+/**
+ * Read the derivation rule stored in a composite service's body column.
+ * Falls back to 'worst-case' if not found or unparseable.
+ */
+function getDerivationRule(compositeId: string): DerivationRule {
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT body FROM services WHERE id = ? AND check_type = ?').get(compositeId, 'composite') as { body: string | null } | undefined;
+    if (row?.body) {
+      const parsed = JSON.parse(row.body) as { derivationRule?: string };
+      if (parsed.derivationRule && ['worst-case', 'majority', 'weighted'].includes(parsed.derivationRule)) {
+        return parsed.derivationRule as DerivationRule;
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return 'worst-case';
+}
+
+// ── Cycle detection (BFS, adapted from dependency-repo pattern) ──
+
+/**
+ * Check if adding childId as a child of compositeId would create a cycle.
+ * Walks the composite_children graph downward from childId; if it reaches
+ * compositeId, a cycle would form.
+ */
+function wouldCreateCycle(compositeId: string, childId: string): boolean {
+  try {
+    const db = getDb();
+    const visited = new Set<string>();
+    const queue = [childId];
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (current === compositeId) return true;
+      if (visited.has(current)) continue;
+      visited.add(current);
+
+      // Walk children of `current` in the composite tree
+      const rows = db.prepare(
+        'SELECT child_id FROM composite_children WHERE composite_id = ?'
+      ).all(current) as { child_id: string }[];
+
+      for (const row of rows) {
+        queue.push(row.child_id);
+      }
+    }
+
+    return false;
+  } catch {
+    // Fail-safe: assume cycle to prevent corruption
+    return true;
+  }
+}
+
+// ── Public API ──
+
+/**
+ * Create a composite service. Inserts a service row with check_type='composite'
+ * and no real URL (uses a placeholder), then optionally adds initial children.
+ */
+export function createCompositeService(
+  name: string,
+  childIds: string[],
+  derivationRule: DerivationRule = 'worst-case',
+): Result<Service> {
+  try {
+    const db = getDb();
+
+    // Validate derivation rule
+    if (!['worst-case', 'majority', 'weighted'].includes(derivationRule)) {
+      return err('VALIDATION', `Invalid derivation rule: ${derivationRule}`);
+    }
+
+    // Validate that all child IDs exist and none are duplicated
+    const uniqueChildIds = [...new Set(childIds)];
+    for (const childId of uniqueChildIds) {
+      const childResult = getService(childId);
+      if (!childResult.ok) {
+        return err('NOT_FOUND', `Child service ${childId} does not exist`);
+      }
+    }
+
+    // Check for duplicate children in input
+    if (uniqueChildIds.length !== childIds.length) {
+      return err('VALIDATION', 'Duplicate child IDs provided');
+    }
+
+    // Create the composite service row
+    // Store the derivation rule in the body column as JSON metadata
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const metadata = JSON.stringify({ derivationRule });
+
+    db.prepare(`
+      INSERT INTO services (id, name, url, method, check_type, expected_status, check_interval, timeout, body, status, enabled, sort_order, created_at, updated_at)
+      VALUES (?, ?, ?, 'GET', 'composite', 200, 60, 10, ?, 'unknown', 1, 0, ?, ?)
+    `).run(id, name, 'composite://aggregate', metadata, now, now);
+
+    // Add children
+    const insertChild = db.prepare(`
+      INSERT INTO composite_children (composite_id, child_id, weight, derivation_rule, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+
+    for (const childId of uniqueChildIds) {
+      insertChild.run(id, childId, 1.0, derivationRule, now);
+    }
+
+    log.info({ id, name, childCount: uniqueChildIds.length, derivationRule }, 'Composite service created');
+
+    return getService(id);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to create composite service');
+    return err('CREATE_FAILED', msg);
+  }
+}
+
+/**
+ * Add a child service to an existing composite service.
+ */
+export function addChild(
+  compositeId: string,
+  childId: string,
+  weight: number = 1.0,
+): Result<CompositeChild> {
+  try {
+    const db = getDb();
+
+    // Verify composite exists and is actually a composite
+    const compositeResult = getService(compositeId);
+    if (!compositeResult.ok) {
+      return err('NOT_FOUND', `Composite service ${compositeId} not found`);
+    }
+    if (compositeResult.data.checkType !== 'composite') {
+      return err('VALIDATION', `Service ${compositeId} is not a composite service`);
+    }
+
+    // Verify child exists
+    const childResult = getService(childId);
+    if (!childResult.ok) {
+      return err('NOT_FOUND', `Child service ${childId} not found`);
+    }
+
+    // Self-reference check
+    if (compositeId === childId) {
+      return err('VALIDATION', 'A composite service cannot contain itself as a child');
+    }
+
+    // Cycle detection
+    if (wouldCreateCycle(compositeId, childId)) {
+      return err('VALIDATION', 'Adding this child would create a circular hierarchy');
+    }
+
+    // Weight validation
+    if (weight <= 0) {
+      return err('VALIDATION', 'Weight must be greater than zero');
+    }
+
+    // Get the derivation rule from the composite service's metadata
+    const derivationRule = getDerivationRule(compositeId);
+
+    const now = new Date().toISOString();
+
+    db.prepare(`
+      INSERT INTO composite_children (composite_id, child_id, weight, derivation_rule, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(compositeId, childId, weight, derivationRule, now);
+
+    log.info({ compositeId, childId, weight }, 'Child added to composite service');
+
+    return ok({
+      compositeId,
+      childId,
+      weight,
+      derivationRule,
+      createdAt: now,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('UNIQUE constraint') || msg.includes('PRIMARY KEY')) {
+      return err('DUPLICATE', 'This child is already part of the composite service');
+    }
+    log.error({ error: msg }, 'Failed to add child to composite service');
+    return err('DB_ERROR', msg);
+  }
+}
+
+/**
+ * Remove a child service from a composite service.
+ */
+export function removeChild(
+  compositeId: string,
+  childId: string,
+): Result<{ removed: true }> {
+  try {
+    const db = getDb();
+
+    const result = db.prepare(
+      'DELETE FROM composite_children WHERE composite_id = ? AND child_id = ?'
+    ).run(compositeId, childId);
+
+    if (result.changes === 0) {
+      return err('NOT_FOUND', `Child ${childId} is not part of composite ${compositeId}`);
+    }
+
+    log.info({ compositeId, childId }, 'Child removed from composite service');
+    return ok({ removed: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to remove child from composite service');
+    return err('DB_ERROR', msg);
+  }
+}
+
+/**
+ * List all children of a composite service with their weights.
+ */
+export function getChildren(compositeId: string): Result<CompositeChild[]> {
+  try {
+    const db = getDb();
+
+    const rows = db.prepare(
+      'SELECT * FROM composite_children WHERE composite_id = ? ORDER BY created_at ASC'
+    ).all(compositeId) as Record<string, unknown>[];
+
+    return ok(rows.map(rowToChild));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to get composite children');
+    return err('DB_ERROR', msg);
+  }
+}
+
+/**
+ * Compute the derived status of a composite service from its children.
+ * Also updates the composite service's status in the database.
+ */
+export function computeStatus(compositeId: string): Result<ServiceStatus> {
+  try {
+    // Get children
+    const childrenResult = getChildren(compositeId);
+    if (!childrenResult.ok) return childrenResult;
+
+    const children = childrenResult.data;
+
+    // No children => unknown
+    if (children.length === 0) {
+      updateServiceStatus(compositeId, 'unknown');
+      return ok('unknown' as ServiceStatus);
+    }
+
+    // Read derivation rule from the composite service's stored metadata
+    const derivationRule = getDerivationRule(compositeId);
+
+    // Gather child statuses
+    const childStatuses: Array<{ status: ServiceStatus; weight: number }> = [];
+    for (const child of children) {
+      const childService = getService(child.childId);
+      if (!childService.ok) {
+        // If a child was deleted, skip it
+        log.warn({ compositeId, childId: child.childId }, 'Child service not found, skipping');
+        continue;
+      }
+      childStatuses.push({
+        status: childService.data.status,
+        weight: child.weight,
+      });
+    }
+
+    // No valid children => unknown
+    if (childStatuses.length === 0) {
+      updateServiceStatus(compositeId, 'unknown');
+      return ok('unknown' as ServiceStatus);
+    }
+
+    let derivedStatus: ServiceStatus;
+
+    switch (derivationRule) {
+      case 'worst-case':
+        derivedStatus = deriveWorstCase(childStatuses);
+        break;
+      case 'majority':
+        derivedStatus = deriveMajority(childStatuses);
+        break;
+      case 'weighted':
+        derivedStatus = deriveWeighted(childStatuses);
+        break;
+      default:
+        derivedStatus = deriveWorstCase(childStatuses);
+    }
+
+    // Persist the derived status
+    updateServiceStatus(compositeId, derivedStatus);
+
+    log.info({ compositeId, derivedStatus, derivationRule, childCount: childStatuses.length }, 'Composite status computed');
+
+    return ok(derivedStatus);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to compute composite status');
+    return err('COMPUTE_FAILED', msg);
+  }
+}
+
+// ── Derivation strategies ──
+
+/**
+ * Worst-case: the composite takes the worst status among all children.
+ * Severity ranking: operational < degraded < partial_outage < major_outage < maintenance < unknown
+ */
+function deriveWorstCase(
+  children: Array<{ status: ServiceStatus; weight: number }>,
+): ServiceStatus {
+  let worstSeverity = 0;
+
+  for (const child of children) {
+    const severity = STATUS_SEVERITY[child.status] ?? 0;
+    if (severity > worstSeverity) {
+      worstSeverity = severity;
+    }
+  }
+
+  return SEVERITY_TO_STATUS[worstSeverity] ?? 'unknown';
+}
+
+/**
+ * Majority: the composite takes whichever status has >50% of children.
+ * If no status has a strict majority, falls back to worst-case.
+ */
+function deriveMajority(
+  children: Array<{ status: ServiceStatus; weight: number }>,
+): ServiceStatus {
+  const counts = new Map<ServiceStatus, number>();
+
+  for (const child of children) {
+    counts.set(child.status, (counts.get(child.status) ?? 0) + 1);
+  }
+
+  const total = children.length;
+
+  // Find status with >50%
+  for (const [status, count] of counts) {
+    if (count > total / 2) {
+      return status;
+    }
+  }
+
+  // No majority — fall back to worst-case
+  return deriveWorstCase(children);
+}
+
+/**
+ * Weighted: each child contributes its weight toward its status.
+ * The status with the highest total weight wins.
+ * Ties are broken by worst severity.
+ */
+function deriveWeighted(
+  children: Array<{ status: ServiceStatus; weight: number }>,
+): ServiceStatus {
+  const weightTotals = new Map<ServiceStatus, number>();
+
+  for (const child of children) {
+    weightTotals.set(child.status, (weightTotals.get(child.status) ?? 0) + child.weight);
+  }
+
+  let maxWeight = -1;
+  let winningStatus: ServiceStatus = 'unknown';
+  let winningSeverity = -1;
+
+  for (const [status, totalWeight] of weightTotals) {
+    const severity = STATUS_SEVERITY[status] ?? 0;
+    if (
+      totalWeight > maxWeight ||
+      (totalWeight === maxWeight && severity > winningSeverity)
+    ) {
+      maxWeight = totalWeight;
+      winningStatus = status;
+      winningSeverity = severity;
+    }
+  }
+
+  return winningStatus;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { startDailyAggregator, stopDailyAggregator } from './monitors/daily-aggr
 import { startPercentileAggregator, stopPercentileAggregator } from './monitors/percentile-aggregator.js';
 import { startReportScheduler, stopReportScheduler } from './reports/index.js';
 import { router } from './api/routes.js';
+import { themeRouter } from './api/theme-config.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const config = loadConfig();
@@ -34,6 +35,7 @@ app.get('/', (_req, res) => {
 
 // API routes
 app.use(router);
+app.use(themeRouter);
 
 // Health endpoint
 app.get('/health', (_req, res) => {

--- a/src/status-page/index.html
+++ b/src/status-page/index.html
@@ -9,6 +9,7 @@
   <title>StatusOwl</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1F989;</text></svg>">
   <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1F989;</text></svg>">
+  <link rel="stylesheet" href="theme.css">
   <link rel="stylesheet" href="status.css">
 </head>
 <body>

--- a/src/status-page/status.css
+++ b/src/status-page/status.css
@@ -1,90 +1,10 @@
 /**
  * StatusOwl — Status Page Styles
  * Clean, professional, modern design with light/dark theme support
+ *
+ * All color values are defined as CSS custom properties in theme.css.
+ * This file references those variables exclusively — no hardcoded hex colors.
  */
-
-/* CSS Custom Properties - Light Theme (default) */
-:root {
-  /* Branding — overridden dynamically via /api/branding */
-  --brand-primary: #2563eb;
-  --brand-accent: #059669;
-
-  --color-operational: #22c55e;
-  --color-degraded: #eab308;
-  --color-partial-outage: #f97316;
-  --color-outage: #ef4444;
-  --color-maintenance: #6366f1;
-  --color-background: #f8fafc;
-  --color-surface: #ffffff;
-  --color-text-primary: #1e293b;
-  --color-text-secondary: #64748b;
-  --color-border: #e2e8f0;
-  --color-shadow: rgba(0, 0, 0, 0.05);
-  --color-focus: var(--brand-primary);
-
-  /* Incident status badge colors */
-  --color-investigating: #facc15;
-  --color-investigating-text: #713f12;
-  --color-identified: #f97316;
-  --color-identified-text: #7c2d12;
-  --color-monitoring: #3b82f6;
-  --color-monitoring-text: #1e3a5f;
-
-  /* Severity badge colors */
-  --color-severity-minor-bg: #fef9c3;
-  --color-severity-minor-text: #a16207;
-  --color-severity-major-bg: #fee2e2;
-  --color-severity-major-text: #b91c1c;
-  --color-severity-critical-bg: #fecaca;
-  --color-severity-critical-text: #991b1b;
-
-  --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-
-  --spacing-xs: 0.25rem;
-  --spacing-sm: 0.5rem;
-  --spacing-md: 1rem;
-  --spacing-lg: 1.5rem;
-  --spacing-xl: 2rem;
-
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
-
-  --transition-fast: 150ms ease;
-  --transition-normal: 250ms ease;
-}
-
-/* Dark Theme */
-[data-theme="dark"] {
-  --color-background: #0f172a;
-  --color-surface: #1e293b;
-  --color-text-primary: #f1f5f9;
-  --color-text-secondary: #94a3b8;
-  --color-border: #334155;
-  --color-shadow: rgba(0, 0, 0, 0.3);
-  --color-focus: var(--brand-primary);
-
-  --color-operational: #4ade80;
-  --color-degraded: #facc15;
-  --color-partial-outage: #fb923c;
-  --color-outage: #f87171;
-  --color-maintenance: #818cf8;
-
-  --color-investigating: #facc15;
-  --color-investigating-text: #422006;
-  --color-identified: #fb923c;
-  --color-identified-text: #431407;
-  --color-monitoring: #60a5fa;
-  --color-monitoring-text: #172554;
-
-  /* Severity badge dark mode */
-  --color-severity-minor-bg: #854d0e;
-  --color-severity-minor-text: #fef9c3;
-  --color-severity-major-bg: #991b1b;
-  --color-severity-major-text: #fee2e2;
-  --color-severity-critical-bg: #7f1d1d;
-  --color-severity-critical-text: #fecaca;
-}
 
 /* Skip Navigation Link */
 .skip-link {
@@ -211,6 +131,23 @@ button:focus-visible {
 .theme-toggle svg {
   width: 18px;
   height: 18px;
+}
+
+/* Show sun icon in dark mode, moon icon in light mode */
+.theme-toggle .sun-icon {
+  display: none;
+}
+
+.theme-toggle .moon-icon {
+  display: block;
+}
+
+[data-theme="dark"] .theme-toggle .sun-icon {
+  display: block;
+}
+
+[data-theme="dark"] .theme-toggle .moon-icon {
+  display: none;
 }
 
 /* Refresh Button */
@@ -507,7 +444,7 @@ button:focus-visible {
 }
 
 .service-status-dot.unknown {
-  background-color: var(--color-text-secondary);
+  background-color: var(--color-unknown);
 }
 
 .service-status-label {
@@ -743,12 +680,8 @@ button:focus-visible {
 }
 
 .incident-status-badge.resolved {
-  background-color: var(--color-operational);
-  color: #14532d;
-}
-
-[data-theme="dark"] .incident-status-badge.resolved {
-  color: #052e16;
+  background-color: var(--color-resolved-badge-bg);
+  color: var(--color-resolved-badge-text);
 }
 
 /* Loading State */
@@ -772,8 +705,8 @@ button:focus-visible {
 }
 
 .retry-btn {
-  background: var(--color-outage);
-  color: #fff;
+  background: var(--color-button-danger);
+  color: var(--color-button-danger-text);
   border: none;
   border-radius: var(--radius-md);
   padding: var(--spacing-sm) var(--spacing-lg);
@@ -814,8 +747,8 @@ button:focus-visible {
 
 /* Maintenance Banner */
 .maintenance-banner {
-  background-color: #fef3c7;
-  border: 1px solid #fbbf24;
+  background-color: var(--color-maintenance-banner-bg);
+  border: 1px solid var(--color-maintenance-banner-border);
   border-radius: var(--radius-md);
   padding: var(--spacing-md) var(--spacing-lg);
   margin-bottom: var(--spacing-md);
@@ -823,25 +756,15 @@ button:focus-visible {
   align-items: center;
   gap: var(--spacing-sm);
   font-size: 0.875rem;
-  color: #92400e;
+  color: var(--color-maintenance-banner-text);
   line-height: 1.4;
-}
-
-[data-theme="dark"] .maintenance-banner {
-  background-color: #451a03;
-  border-color: #b45309;
-  color: #fde68a;
 }
 
 .maintenance-banner-icon {
   flex-shrink: 0;
   width: 20px;
   height: 20px;
-  color: #d97706;
-}
-
-[data-theme="dark"] .maintenance-banner-icon {
-  color: #fbbf24;
+  color: var(--color-maintenance-banner-icon);
 }
 
 .maintenance-banner-items {
@@ -1175,11 +1098,11 @@ button:focus-visible {
 }
 
 .sse-indicator.connected {
-  background-color: #4c1;
+  background-color: var(--color-sse-connected);
 }
 
 .sse-indicator.disconnected {
-  background-color: #e05d44;
+  background-color: var(--color-sse-disconnected);
 }
 
 .sse-status {

--- a/src/status-page/status.js
+++ b/src/status-page/status.js
@@ -1062,13 +1062,23 @@
 
   var API_CALENDAR_URL = '/api/calendar';
 
-  var CALENDAR_COLORS = {
-    4: '#2d6a4f',
-    3: '#52b788',
-    2: '#b7e4c7',
-    1: '#fca311',
-    0: '#e63946',
-  };
+  /**
+   * Calendar heat-map colors — reads from CSS custom properties so they
+   * automatically switch between light and dark theme.
+   */
+  function getCalendarColors() {
+    var style = getComputedStyle(document.documentElement);
+    return {
+      4: style.getPropertyValue('--color-calendar-level-4').trim() || '#2d6a4f',
+      3: style.getPropertyValue('--color-calendar-level-3').trim() || '#52b788',
+      2: style.getPropertyValue('--color-calendar-level-2').trim() || '#b7e4c7',
+      1: style.getPropertyValue('--color-calendar-level-1').trim() || '#fca311',
+      0: style.getPropertyValue('--color-calendar-level-0').trim() || '#e63946',
+    };
+  }
+
+  // Lazy-initialized; refreshed each time the calendar renders
+  var CALENDAR_COLORS = null;
 
   var CALENDAR_CELL_SIZE = 12;
   var CALENDAR_GAP = 2;
@@ -1109,6 +1119,9 @@
    *   - Month labels on top
    */
   function renderCalendar(containerId, calendarData) {
+    // Refresh calendar colors from CSS custom properties (theme-aware)
+    CALENDAR_COLORS = getCalendarColors();
+
     var container = document.getElementById(containerId);
     if (!container) return;
 

--- a/src/status-page/theme.css
+++ b/src/status-page/theme.css
@@ -1,0 +1,206 @@
+/**
+ * StatusOwl — Theme Definitions
+ *
+ * CSS custom properties for all colors used in the status page.
+ * Light theme is the default (:root). Dark theme activates via [data-theme="dark"].
+ *
+ * Every color reference in status.css and the status page JS must use these
+ * variables — no hardcoded hex values outside this file.
+ */
+
+/* ── Light Theme (default) ── */
+:root {
+  /* Branding — overridden dynamically via /api/branding */
+  --brand-primary: #2563eb;
+  --brand-accent: #059669;
+
+  /* Core palette */
+  --color-background: #f8fafc;
+  --color-surface: #ffffff;
+  --color-text-primary: #1e293b;
+  --color-text-secondary: #64748b;
+  --color-text-muted: #94a3b8;
+  --color-border: #e2e8f0;
+  --color-shadow: rgba(0, 0, 0, 0.05);
+  --color-focus: var(--brand-primary);
+
+  /* Status colors */
+  --color-operational: #22c55e;
+  --color-degraded: #eab308;
+  --color-partial-outage: #f97316;
+  --color-outage: #ef4444;
+  --color-maintenance: #6366f1;
+  --color-unknown: #94a3b8;
+
+  /* Incident status badge colors */
+  --color-investigating: #facc15;
+  --color-investigating-text: #713f12;
+  --color-identified: #f97316;
+  --color-identified-text: #7c2d12;
+  --color-monitoring: #3b82f6;
+  --color-monitoring-text: #1e3a5f;
+  --color-resolved-badge-bg: #22c55e;
+  --color-resolved-badge-text: #14532d;
+
+  /* Severity badge colors */
+  --color-severity-minor-bg: #fef9c3;
+  --color-severity-minor-text: #a16207;
+  --color-severity-major-bg: #fee2e2;
+  --color-severity-major-text: #b91c1c;
+  --color-severity-critical-bg: #fecaca;
+  --color-severity-critical-text: #991b1b;
+
+  /* Maintenance banner */
+  --color-maintenance-banner-bg: #fef3c7;
+  --color-maintenance-banner-border: #fbbf24;
+  --color-maintenance-banner-text: #92400e;
+  --color-maintenance-banner-icon: #d97706;
+
+  /* SSE connection indicator */
+  --color-sse-connected: #4c1;
+  --color-sse-disconnected: #e05d44;
+
+  /* Calendar heat map levels (0 = worst, 4 = best) */
+  --color-calendar-level-0: #e63946;
+  --color-calendar-level-1: #fca311;
+  --color-calendar-level-2: #b7e4c7;
+  --color-calendar-level-3: #52b788;
+  --color-calendar-level-4: #2d6a4f;
+
+  /* Sparkline */
+  --color-sparkline-stroke: #2563eb;
+  --color-sparkline-fill: rgba(37, 99, 235, 0.1);
+
+  /* Misc */
+  --color-button-danger: #ef4444;
+  --color-button-danger-text: #ffffff;
+
+  /* Typography */
+  --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+
+  /* Spacing */
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+
+  /* Border radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+}
+
+/* ── Dark Theme ── */
+[data-theme="dark"] {
+  /* Core palette */
+  --color-background: #0f172a;
+  --color-surface: #1e293b;
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #64748b;
+  --color-border: #334155;
+  --color-shadow: rgba(0, 0, 0, 0.3);
+  --color-focus: var(--brand-primary);
+
+  /* Status colors — brighter variants for dark backgrounds */
+  --color-operational: #4ade80;
+  --color-degraded: #facc15;
+  --color-partial-outage: #fb923c;
+  --color-outage: #f87171;
+  --color-maintenance: #818cf8;
+  --color-unknown: #64748b;
+
+  /* Incident status badge colors */
+  --color-investigating: #facc15;
+  --color-investigating-text: #422006;
+  --color-identified: #fb923c;
+  --color-identified-text: #431407;
+  --color-monitoring: #60a5fa;
+  --color-monitoring-text: #172554;
+  --color-resolved-badge-bg: #4ade80;
+  --color-resolved-badge-text: #052e16;
+
+  /* Severity badge colors */
+  --color-severity-minor-bg: #854d0e;
+  --color-severity-minor-text: #fef9c3;
+  --color-severity-major-bg: #991b1b;
+  --color-severity-major-text: #fee2e2;
+  --color-severity-critical-bg: #7f1d1d;
+  --color-severity-critical-text: #fecaca;
+
+  /* Maintenance banner */
+  --color-maintenance-banner-bg: #451a03;
+  --color-maintenance-banner-border: #b45309;
+  --color-maintenance-banner-text: #fde68a;
+  --color-maintenance-banner-icon: #fbbf24;
+
+  /* SSE connection indicator */
+  --color-sse-connected: #4ade80;
+  --color-sse-disconnected: #f87171;
+
+  /* Calendar heat map levels — softer on dark bg */
+  --color-calendar-level-0: #f87171;
+  --color-calendar-level-1: #fbbf24;
+  --color-calendar-level-2: #86efac;
+  --color-calendar-level-3: #34d399;
+  --color-calendar-level-4: #059669;
+
+  /* Sparkline */
+  --color-sparkline-stroke: #60a5fa;
+  --color-sparkline-fill: rgba(96, 165, 250, 0.15);
+
+  /* Misc */
+  --color-button-danger: #f87171;
+  --color-button-danger-text: #1e293b;
+}
+
+/* ── Theme transition ── */
+html,
+html body,
+html .container,
+html .header,
+html .status-banner,
+html .services-section,
+html .incidents-section,
+html .calendar-section,
+html .service-item,
+html .service-group-header,
+html .incident-item,
+html .incident-header,
+html .footer,
+html .maintenance-banner,
+html .theme-toggle,
+html .refresh-btn {
+  transition: background-color 0.3s ease,
+              color 0.3s ease,
+              border-color 0.3s ease,
+              box-shadow 0.3s ease;
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  html,
+  html body,
+  html .container,
+  html .header,
+  html .status-banner,
+  html .services-section,
+  html .incidents-section,
+  html .calendar-section,
+  html .service-item,
+  html .service-group-header,
+  html .incident-item,
+  html .incident-header,
+  html .footer,
+  html .maintenance-banner,
+  html .theme-toggle,
+  html .refresh-btn {
+    transition: none;
+  }
+}

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -360,6 +360,60 @@ function runMigrations(db: Database.Database): void {
         CREATE UNIQUE INDEX IF NOT EXISTS idx_sla_targets_service ON sla_targets(service_id);
       `,
     },
+    {
+      version: 14,
+      sql: `
+        -- Maintenance notification tracking (prevents duplicate sends)
+        CREATE TABLE IF NOT EXISTS maintenance_notifications (
+          id TEXT PRIMARY KEY,
+          maintenance_window_id TEXT NOT NULL REFERENCES maintenance_windows(id) ON DELETE CASCADE,
+          notification_type TEXT NOT NULL CHECK (notification_type IN ('upcoming', 'started', 'ended')),
+          sent_at TEXT NOT NULL DEFAULT (datetime('now')),
+          UNIQUE(maintenance_window_id, notification_type)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_maint_notif_window ON maintenance_notifications(maintenance_window_id);
+      `,
+    },
+    {
+      version: 15,
+      sql: `
+        -- Service tags / labels
+        CREATE TABLE IF NOT EXISTS tags (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL UNIQUE,
+          color TEXT NOT NULL DEFAULT '#3b82f6',
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        -- Junction table: service <-> tag (many-to-many)
+        CREATE TABLE IF NOT EXISTS service_tags (
+          service_id TEXT NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+          tag_id TEXT NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+          PRIMARY KEY (service_id, tag_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_service_tags_tag ON service_tags(tag_id);
+      `,
+    },
+    {
+      version: 16,
+      sql: `
+        -- Composite service children with derivation rules
+        CREATE TABLE IF NOT EXISTS composite_children (
+          composite_id TEXT NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+          child_id TEXT NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+          weight REAL NOT NULL DEFAULT 1.0,
+          derivation_rule TEXT NOT NULL DEFAULT 'worst-case'
+            CHECK (derivation_rule IN ('worst-case', 'majority', 'weighted')),
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          PRIMARY KEY (composite_id, child_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_composite_children_composite ON composite_children(composite_id);
+        CREATE INDEX IF NOT EXISTS idx_composite_children_child ON composite_children(child_id);
+      `,
+    },
   ];
 
   const applyMigration = db.transaction((m: { version: number; sql: string }) => {

--- a/src/storage/tag-repo.ts
+++ b/src/storage/tag-repo.ts
@@ -1,0 +1,222 @@
+/**
+ * StatusOwl — Tag Repository
+ *
+ * CRUD operations for service tags/labels and service-tag associations.
+ * Supports filtering services by tags in AND/OR modes.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDb } from './database.js';
+import { ok, err, createChildLogger } from '../core/index.js';
+import type { Result, Tag, ServiceTag } from '../core/index.js';
+
+const log = createChildLogger('TagRepo');
+
+/** Predefined color palette for tags when no color is specified. */
+const DEFAULT_COLORS = [
+  '#3b82f6', // blue
+  '#10b981', // emerald
+  '#f59e0b', // amber
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#ec4899', // pink
+  '#06b6d4', // cyan
+  '#f97316', // orange
+  '#14b8a6', // teal
+  '#6366f1', // indigo
+];
+
+/** Track how many tags have been created to rotate through default colors. */
+function nextDefaultColor(): string {
+  const db = getDb();
+  const row = db.prepare('SELECT COUNT(*) as count FROM tags').get() as { count: number };
+  return DEFAULT_COLORS[row.count % DEFAULT_COLORS.length];
+}
+
+function rowToTag(row: Record<string, unknown>): Tag {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    color: row.color as string,
+    createdAt: row.created_at as string,
+  };
+}
+
+function rowToServiceTag(row: Record<string, unknown>): ServiceTag {
+  return {
+    serviceId: row.service_id as string,
+    tagId: row.tag_id as string,
+  };
+}
+
+// ── Tag CRUD ──
+
+export function createTag(name: string, color?: string): Result<Tag> {
+  try {
+    const db = getDb();
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const tagColor = color ?? nextDefaultColor();
+
+    db.prepare(`
+      INSERT INTO tags (id, name, color, created_at)
+      VALUES (?, ?, ?, ?)
+    `).run(id, name.trim(), tagColor, now);
+
+    log.info({ id, name, color: tagColor }, 'Tag created');
+    return ok({ id, name: name.trim(), color: tagColor, createdAt: now });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('UNIQUE constraint')) {
+      return err('DUPLICATE', `Tag "${name}" already exists`);
+    }
+    log.error({ error: msg }, 'Failed to create tag');
+    return err('CREATE_FAILED', msg);
+  }
+}
+
+export function getTag(id: string): Result<Tag> {
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM tags WHERE id = ?').get(id) as Record<string, unknown> | undefined;
+
+    if (!row) return err('NOT_FOUND', `Tag ${id} not found`);
+
+    return ok(rowToTag(row));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return err('QUERY_FAILED', msg);
+  }
+}
+
+export function listTags(): Result<Tag[]> {
+  try {
+    const db = getDb();
+    const rows = db.prepare('SELECT * FROM tags ORDER BY name ASC').all() as Record<string, unknown>[];
+    return ok(rows.map(rowToTag));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to list tags');
+    return err('QUERY_FAILED', msg);
+  }
+}
+
+export function deleteTag(id: string): Result<void> {
+  try {
+    const db = getDb();
+    const result = db.prepare('DELETE FROM tags WHERE id = ?').run(id);
+    if (result.changes === 0) return err('NOT_FOUND', `Tag ${id} not found`);
+    log.info({ id }, 'Tag deleted');
+    return ok(undefined);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to delete tag');
+    return err('DELETE_FAILED', msg);
+  }
+}
+
+// ── Service-Tag Associations ──
+
+export function addTagToService(serviceId: string, tagId: string): Result<ServiceTag> {
+  try {
+    const db = getDb();
+
+    db.prepare(`
+      INSERT INTO service_tags (service_id, tag_id)
+      VALUES (?, ?)
+    `).run(serviceId, tagId);
+
+    log.info({ serviceId, tagId }, 'Tag added to service');
+    return ok({ serviceId, tagId });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('UNIQUE constraint') || msg.includes('PRIMARY KEY')) {
+      return err('DUPLICATE', 'This tag is already assigned to the service');
+    }
+    if (msg.includes('FOREIGN KEY constraint')) {
+      return err('NOT_FOUND', 'Service or tag not found');
+    }
+    log.error({ error: msg }, 'Failed to add tag to service');
+    return err('CREATE_FAILED', msg);
+  }
+}
+
+export function removeTagFromService(serviceId: string, tagId: string): Result<void> {
+  try {
+    const db = getDb();
+    const result = db.prepare('DELETE FROM service_tags WHERE service_id = ? AND tag_id = ?').run(serviceId, tagId);
+    if (result.changes === 0) return err('NOT_FOUND', 'Tag is not assigned to this service');
+    log.info({ serviceId, tagId }, 'Tag removed from service');
+    return ok(undefined);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to remove tag from service');
+    return err('DELETE_FAILED', msg);
+  }
+}
+
+export function getTagsForService(serviceId: string): Result<Tag[]> {
+  try {
+    const db = getDb();
+    const rows = db.prepare(`
+      SELECT t.* FROM tags t
+      INNER JOIN service_tags st ON st.tag_id = t.id
+      WHERE st.service_id = ?
+      ORDER BY t.name ASC
+    `).all(serviceId) as Record<string, unknown>[];
+
+    return ok(rows.map(rowToTag));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg }, 'Failed to get tags for service');
+    return err('QUERY_FAILED', msg);
+  }
+}
+
+// ── Query: Filter Services by Tags ──
+
+/**
+ * Get service IDs that match the given tag IDs.
+ *
+ * @param tagIds - Array of tag IDs to filter by.
+ * @param mode - 'or' returns services matching ANY tag, 'and' returns services matching ALL tags.
+ * @returns Array of service IDs matching the filter criteria.
+ */
+export function getServicesByTag(tagIds: string[], mode: 'and' | 'or'): Result<string[]> {
+  if (tagIds.length === 0) {
+    return ok([]);
+  }
+
+  try {
+    const db = getDb();
+    const placeholders = tagIds.map(() => '?').join(',');
+
+    if (mode === 'or') {
+      // OR mode: return services that have at least one of the specified tags
+      const rows = db.prepare(`
+        SELECT DISTINCT service_id
+        FROM service_tags
+        WHERE tag_id IN (${placeholders})
+        ORDER BY service_id
+      `).all(...tagIds) as { service_id: string }[];
+
+      return ok(rows.map(r => r.service_id));
+    }
+
+    // AND mode: return services that have ALL of the specified tags
+    const rows = db.prepare(`
+      SELECT service_id
+      FROM service_tags
+      WHERE tag_id IN (${placeholders})
+      GROUP BY service_id
+      HAVING COUNT(DISTINCT tag_id) = ?
+      ORDER BY service_id
+    `).all(...tagIds, tagIds.length) as { service_id: string }[];
+
+    return ok(rows.map(r => r.service_id));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.error({ error: msg, tagIds, mode }, 'Failed to get services by tag');
+    return err('QUERY_FAILED', msg);
+  }
+}

--- a/tests/bulk-operations.test.ts
+++ b/tests/bulk-operations.test.ts
@@ -1,0 +1,735 @@
+/**
+ * Bulk Operations Tests
+ *
+ * Tests for batch create, update, and delete of services.
+ * Covers atomic/partial modes, validation, limits, and audit log integration.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
+import { z } from 'zod';
+import { bulkCreateServices, bulkUpdateServices, bulkDeleteServices } from '../src/api/bulk-operations.js';
+import { createService, getService, listServices } from '../src/storage/service-repo.js';
+import { queryAuditLog } from '../src/audit/audit-repo.js';
+import { getDb, closeDb } from '../src/storage/database.js';
+import { CreateServiceSchema } from '../src/core/contracts.js';
+import type { CreateService } from '../src/core/index.js';
+
+function makeService(overrides: Partial<CreateService> = {}): CreateService {
+  return {
+    name: overrides.name ?? 'Test Service',
+    url: overrides.url ?? 'https://example.com/health',
+    ...overrides,
+  };
+}
+
+function makeServices(count: number): CreateService[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeService({ name: `Service ${i + 1}`, url: `https://svc-${i + 1}.example.com/health` })
+  );
+}
+
+describe('Bulk Operations', () => {
+  let db: ReturnType<typeof getDb>;
+
+  beforeAll(() => {
+    process.env.DB_PATH = ':memory:';
+    process.env.LOG_LEVEL = 'error';
+    db = getDb();
+  });
+
+  afterAll(() => {
+    closeDb();
+  });
+
+  beforeEach(() => {
+    // Clean all relevant tables before each test
+    db.prepare('DELETE FROM audit_log').run();
+    db.prepare('DELETE FROM incident_updates').run();
+    db.prepare('DELETE FROM incident_services').run();
+    db.prepare('DELETE FROM incidents').run();
+    db.prepare('DELETE FROM check_results').run();
+    db.prepare('DELETE FROM services').run();
+    db.prepare('DELETE FROM service_groups').run();
+  });
+
+  // ── Bulk Create ──
+
+  describe('bulkCreateServices', () => {
+    it('should create a single service', () => {
+      const result = bulkCreateServices([makeService({ name: 'Solo Service' })]);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.total).toBe(1);
+      expect(result.data.succeeded).toBe(1);
+      expect(result.data.failed).toBe(0);
+      expect(result.data.results).toHaveLength(1);
+      expect(result.data.results[0].ok).toBe(true);
+      expect(result.data.results[0].data?.name).toBe('Solo Service');
+      expect(result.data.results[0].index).toBe(0);
+    });
+
+    it('should create 10 services atomically', () => {
+      const services = makeServices(10);
+      const result = bulkCreateServices(services);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.total).toBe(10);
+      expect(result.data.succeeded).toBe(10);
+      expect(result.data.failed).toBe(0);
+      expect(result.data.mode).toBe('atomic');
+
+      // Verify all exist in the database
+      const listed = listServices();
+      expect(listed.ok).toBe(true);
+      if (!listed.ok) return;
+      expect(listed.data).toHaveLength(10);
+    });
+
+    it('should create 50 services atomically', () => {
+      const services = makeServices(50);
+      const result = bulkCreateServices(services);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.total).toBe(50);
+      expect(result.data.succeeded).toBe(50);
+      expect(result.data.failed).toBe(0);
+
+      const listed = listServices();
+      expect(listed.ok).toBe(true);
+      if (!listed.ok) return;
+      expect(listed.data).toHaveLength(50);
+    });
+
+    it('should assign unique IDs to each created service', () => {
+      const services = makeServices(5);
+      const result = bulkCreateServices(services);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const ids = result.data.results.map(r => r.data?.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(5);
+    });
+
+    it('should preserve service fields correctly in batch', () => {
+      const services: CreateService[] = [
+        makeService({ name: 'API', url: 'https://api.example.com', method: 'POST', checkInterval: 30 }),
+        makeService({ name: 'Web', url: 'https://web.example.com', expectedStatus: 301, timeout: 5 }),
+        makeService({ name: 'DB', url: 'https://db.example.com', enabled: false }),
+      ];
+
+      const result = bulkCreateServices(services);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.data.results[0].data?.method).toBe('POST');
+      expect(result.data.results[0].data?.checkInterval).toBe(30);
+      expect(result.data.results[1].data?.expectedStatus).toBe(301);
+      expect(result.data.results[1].data?.timeout).toBe(5);
+      expect(result.data.results[2].data?.enabled).toBe(false);
+    });
+
+    it('should create audit log entries for each created service', () => {
+      const services = makeServices(3);
+      bulkCreateServices(services);
+
+      const audit = queryAuditLog({ action: 'service.create' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      expect(audit.data.entries).toHaveLength(3);
+      expect(audit.data.entries.every(e => e.resourceType === 'service')).toBe(true);
+      expect(audit.data.entries.every(e => e.detail?.startsWith('Bulk create:'))).toBe(true);
+    });
+  });
+
+  // ── Bulk Update ──
+
+  describe('bulkUpdateServices', () => {
+    it('should update partial fields on multiple services', () => {
+      // Create services first
+      const svc1 = createService(makeService({ name: 'Update A', url: 'https://a.example.com' }));
+      const svc2 = createService(makeService({ name: 'Update B', url: 'https://b.example.com' }));
+      expect(svc1.ok).toBe(true);
+      expect(svc2.ok).toBe(true);
+      if (!svc1.ok || !svc2.ok) return;
+
+      const result = bulkUpdateServices([
+        { id: svc1.data.id, name: 'Updated A', checkInterval: 120 },
+        { id: svc2.data.id, enabled: false },
+      ]);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.succeeded).toBe(2);
+      expect(result.data.failed).toBe(0);
+      expect(result.data.results[0].data?.name).toBe('Updated A');
+      expect(result.data.results[0].data?.checkInterval).toBe(120);
+      expect(result.data.results[0].data?.url).toBe('https://a.example.com'); // unchanged
+      expect(result.data.results[1].data?.enabled).toBe(false);
+      expect(result.data.results[1].data?.name).toBe('Update B'); // unchanged
+    });
+
+    it('should update a single field across multiple services', () => {
+      const svcs = makeServices(5).map(s => createService(s));
+      const ids = svcs.map(r => {
+        expect(r.ok).toBe(true);
+        if (!r.ok) throw new Error('Setup failed');
+        return r.data.id;
+      });
+
+      const result = bulkUpdateServices(
+        ids.map(id => ({ id, enabled: false }))
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.succeeded).toBe(5);
+      expect(result.data.results.every(r => r.data?.enabled === false)).toBe(true);
+    });
+
+    it('should create audit log entries for each updated service', () => {
+      const svc = createService(makeService());
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      db.prepare('DELETE FROM audit_log').run();
+
+      bulkUpdateServices([{ id: svc.data.id, name: 'Audited Update' }]);
+
+      const audit = queryAuditLog({ action: 'service.update' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      expect(audit.data.entries).toHaveLength(1);
+      expect(audit.data.entries[0].resourceId).toBe(svc.data.id);
+      expect(audit.data.entries[0].detail).toContain('Bulk update');
+    });
+  });
+
+  // ── Bulk Delete ──
+
+  describe('bulkDeleteServices', () => {
+    it('should delete multiple services atomically', () => {
+      const svcs = makeServices(3).map(s => createService(s));
+      const ids = svcs.map(r => {
+        expect(r.ok).toBe(true);
+        if (!r.ok) throw new Error('Setup failed');
+        return r.data.id;
+      });
+
+      const result = bulkDeleteServices(ids);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.succeeded).toBe(3);
+      expect(result.data.failed).toBe(0);
+      expect(result.data.results).toHaveLength(3);
+
+      // Verify all are gone
+      for (const id of ids) {
+        const fetched = getService(id);
+        expect(fetched.ok).toBe(false);
+      }
+    });
+
+    it('should return deleted IDs in results', () => {
+      const svc = createService(makeService());
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      const result = bulkDeleteServices([svc.data.id]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.results[0].data?.id).toBe(svc.data.id);
+    });
+
+    it('should create audit log entries for each deleted service', () => {
+      const svcs = makeServices(2).map(s => createService(s));
+      const ids = svcs.map(r => {
+        expect(r.ok).toBe(true);
+        if (!r.ok) throw new Error('Setup failed');
+        return r.data.id;
+      });
+
+      db.prepare('DELETE FROM audit_log').run();
+
+      bulkDeleteServices(ids);
+
+      const audit = queryAuditLog({ action: 'service.delete' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      expect(audit.data.entries).toHaveLength(2);
+      expect(audit.data.entries.every(e => e.detail === 'Bulk delete')).toBe(true);
+    });
+  });
+
+  // ── Atomic Transaction Mode ──
+
+  describe('Transaction mode (atomic)', () => {
+    it('should rollback all updates if any one fails', () => {
+      const svc = createService(makeService({ name: 'Existing' }));
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      // Try to update: one valid ID, one non-existent ID
+      const result = bulkUpdateServices([
+        { id: svc.data.id, name: 'Should Rollback' },
+        { id: '00000000-0000-0000-0000-000000000000', name: 'Does Not Exist' },
+      ], 'atomic');
+
+      // Should fail entirely
+      expect(result.ok).toBe(false);
+
+      // Verify the first service was NOT updated (rollback)
+      const fetched = getService(svc.data.id);
+      expect(fetched.ok).toBe(true);
+      if (!fetched.ok) return;
+      expect(fetched.data.name).toBe('Existing');
+    });
+
+    it('should rollback all deletes if any one fails', () => {
+      const svc = createService(makeService({ name: 'Keep Me' }));
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      const result = bulkDeleteServices(
+        [svc.data.id, '00000000-0000-0000-0000-000000000000'],
+        'atomic'
+      );
+
+      // Should fail entirely
+      expect(result.ok).toBe(false);
+
+      // The existing service should NOT have been deleted (rollback)
+      const fetched = getService(svc.data.id);
+      expect(fetched.ok).toBe(true);
+      if (!fetched.ok) return;
+      expect(fetched.data.name).toBe('Keep Me');
+    });
+
+    it('should not create audit entries on atomic rollback', () => {
+      const svc = createService(makeService());
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      // Clear audit log from the create above
+      db.prepare('DELETE FROM audit_log').run();
+
+      bulkUpdateServices([
+        { id: svc.data.id, name: 'Rolled Back' },
+        { id: '00000000-0000-0000-0000-000000000000', name: 'Fail' },
+      ], 'atomic');
+
+      const audit = queryAuditLog({ action: 'service.update' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      // Audit entries should have been rolled back along with the data changes
+      expect(audit.data.entries).toHaveLength(0);
+    });
+  });
+
+  // ── Partial Mode ──
+
+  describe('Partial mode', () => {
+    it('should continue on error and report per-item results for update', () => {
+      const svc = createService(makeService({ name: 'Partial Test' }));
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      const result = bulkUpdateServices([
+        { id: svc.data.id, name: 'Updated OK' },
+        { id: '00000000-0000-0000-0000-000000000000', name: 'Will Fail' },
+      ], 'partial');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.mode).toBe('partial');
+      expect(result.data.total).toBe(2);
+      expect(result.data.succeeded).toBe(1);
+      expect(result.data.failed).toBe(1);
+
+      // First item succeeded
+      expect(result.data.results[0].ok).toBe(true);
+      expect(result.data.results[0].data?.name).toBe('Updated OK');
+
+      // Second item failed
+      expect(result.data.results[1].ok).toBe(false);
+      expect(result.data.results[1].error?.code).toBe('UPDATE_FAILED');
+
+      // Verify the first update actually persisted
+      const fetched = getService(svc.data.id);
+      expect(fetched.ok).toBe(true);
+      if (!fetched.ok) return;
+      expect(fetched.data.name).toBe('Updated OK');
+    });
+
+    it('should continue on error and report per-item results for delete', () => {
+      const svc = createService(makeService({ name: 'Delete Partial' }));
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      const result = bulkDeleteServices(
+        [svc.data.id, '00000000-0000-0000-0000-000000000000'],
+        'partial'
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.succeeded).toBe(1);
+      expect(result.data.failed).toBe(1);
+      expect(result.data.results[0].ok).toBe(true);
+      expect(result.data.results[1].ok).toBe(false);
+
+      // Verify the first delete persisted
+      const fetched = getService(svc.data.id);
+      expect(fetched.ok).toBe(false);
+    });
+
+    it('should report ok: false in response when any item fails in partial mode', () => {
+      const result = bulkDeleteServices(
+        ['00000000-0000-0000-0000-000000000000'],
+        'partial'
+      );
+
+      expect(result.ok).toBe(true); // Result wrapper is ok
+      if (!result.ok) return;
+      expect(result.data.ok).toBe(false); // Inner response reflects failures
+      expect(result.data.failed).toBe(1);
+    });
+
+    it('should report ok: true in response when all items succeed in partial mode', () => {
+      const svc = createService(makeService());
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      const result = bulkDeleteServices([svc.data.id], 'partial');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.ok).toBe(true);
+      expect(result.data.succeeded).toBe(1);
+      expect(result.data.failed).toBe(0);
+    });
+
+    it('should preserve correct index in per-item results', () => {
+      const svc1 = createService(makeService({ name: 'Svc 1', url: 'https://s1.example.com' }));
+      const svc2 = createService(makeService({ name: 'Svc 2', url: 'https://s2.example.com' }));
+      expect(svc1.ok && svc2.ok).toBe(true);
+      if (!svc1.ok || !svc2.ok) return;
+
+      const result = bulkUpdateServices([
+        { id: svc1.data.id, name: 'One' },
+        { id: '00000000-0000-0000-0000-000000000000', name: 'Fail' },
+        { id: svc2.data.id, name: 'Three' },
+      ], 'partial');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.results[0].index).toBe(0);
+      expect(result.data.results[0].ok).toBe(true);
+      expect(result.data.results[1].index).toBe(1);
+      expect(result.data.results[1].ok).toBe(false);
+      expect(result.data.results[2].index).toBe(2);
+      expect(result.data.results[2].ok).toBe(true);
+    });
+
+    it('should create audit entries only for successful items in partial mode', () => {
+      const svc = createService(makeService());
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      db.prepare('DELETE FROM audit_log').run();
+
+      bulkUpdateServices([
+        { id: svc.data.id, name: 'Audited' },
+        { id: '00000000-0000-0000-0000-000000000000', name: 'Fail' },
+      ], 'partial');
+
+      const audit = queryAuditLog({ action: 'service.update' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      // Only the successful item should have an audit entry
+      expect(audit.data.entries).toHaveLength(1);
+      expect(audit.data.entries[0].resourceId).toBe(svc.data.id);
+    });
+  });
+
+  // ── Max Batch Size ──
+
+  describe('Max batch size limit', () => {
+    it('should accept exactly 100 items', () => {
+      const services = makeServices(100);
+      const result = bulkCreateServices(services);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.total).toBe(100);
+      expect(result.data.succeeded).toBe(100);
+    });
+
+    // Note: The 100-item limit is enforced at the Zod schema level in the
+    // Express route handlers (BulkCreateSchema, BulkUpdateSchema, BulkDeleteSchema).
+    // The schema uses z.array(...).max(MAX_BATCH_SIZE) to reject payloads > 100 items.
+    // Direct function calls bypass route-level validation by design.
+  });
+
+  // ── Validation Errors ──
+
+  describe('Validation errors', () => {
+    it('should reject services with invalid URLs at schema level', () => {
+      // The CreateServiceSchema.url requires a valid URL via z.string().url()
+      // This validation is enforced at the route handler level via Zod parsing.
+      const parsed = CreateServiceSchema.safeParse({
+        name: 'Test',
+        url: 'not-a-url',
+      });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('should reject services with empty name at schema level', () => {
+      const parsed = CreateServiceSchema.safeParse({
+        name: '',
+        url: 'https://example.com',
+      });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('should reject services with name exceeding max length at schema level', () => {
+      const parsed = CreateServiceSchema.safeParse({
+        name: 'X'.repeat(201),
+        url: 'https://example.com',
+      });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('should reject batch over 100 items at schema level', () => {
+      const BulkCreateSchema = z.object({
+        services: z.array(CreateServiceSchema).min(1).max(100),
+      });
+
+      const tooMany = Array.from({ length: 101 }, (_, i) => ({
+        name: `Svc ${i}`,
+        url: `https://svc-${i}.example.com`,
+      }));
+
+      const parsed = BulkCreateSchema.safeParse({ services: tooMany });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('should reject empty batch at schema level', () => {
+      const BulkCreateSchema = z.object({
+        services: z.array(CreateServiceSchema).min(1).max(100),
+      });
+
+      const parsed = BulkCreateSchema.safeParse({ services: [] });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('should reject bulk delete with invalid UUID format at schema level', () => {
+      const BulkDeleteSchema = z.object({
+        ids: z.array(z.string().uuid()).min(1).max(100),
+      });
+
+      const parsed = BulkDeleteSchema.safeParse({ ids: ['not-a-uuid'] });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('should reject bulk update items missing id at schema level', () => {
+      const BulkUpdateItemSchema = z.object({
+        id: z.string().uuid(),
+      }).and(CreateServiceSchema.partial());
+      const BulkUpdateSchema = z.object({
+        updates: z.array(BulkUpdateItemSchema).min(1).max(100),
+      });
+
+      const parsed = BulkUpdateSchema.safeParse({
+        updates: [{ name: 'No ID provided' }],
+      });
+      expect(parsed.success).toBe(false);
+    });
+  });
+
+  // ── Audit Log Integration ──
+
+  describe('Audit log integration', () => {
+    it('should record audit entries for bulk create with correct details', () => {
+      bulkCreateServices([
+        makeService({ name: 'Audit Service A' }),
+        makeService({ name: 'Audit Service B' }),
+      ]);
+
+      const audit = queryAuditLog({ action: 'service.create' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      expect(audit.data.entries).toHaveLength(2);
+
+      const details = audit.data.entries.map(e => e.detail).sort();
+      expect(details).toContain('Bulk create: Audit Service A');
+      expect(details).toContain('Bulk create: Audit Service B');
+    });
+
+    it('should record audit entries for bulk update with changed field names', () => {
+      const svc = createService(makeService({ name: 'Audit Update Svc' }));
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      db.prepare('DELETE FROM audit_log').run();
+
+      bulkUpdateServices([
+        { id: svc.data.id, name: 'New Name', checkInterval: 30 },
+      ]);
+
+      const audit = queryAuditLog({ action: 'service.update' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      expect(audit.data.entries).toHaveLength(1);
+      expect(audit.data.entries[0].detail).toContain('name');
+      expect(audit.data.entries[0].detail).toContain('checkInterval');
+    });
+
+    it('should record audit entries for bulk delete', () => {
+      const svc = createService(makeService());
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+      const id = svc.data.id;
+
+      db.prepare('DELETE FROM audit_log').run();
+
+      bulkDeleteServices([id]);
+
+      const audit = queryAuditLog({ action: 'service.delete' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      expect(audit.data.entries).toHaveLength(1);
+      expect(audit.data.entries[0].resourceId).toBe(id);
+      expect(audit.data.entries[0].detail).toBe('Bulk delete');
+    });
+
+    it('should set resourceType to service for all bulk operations', () => {
+      const svc = createService(makeService());
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      db.prepare('DELETE FROM audit_log').run();
+
+      bulkUpdateServices([{ id: svc.data.id, name: 'Checked' }]);
+      bulkDeleteServices([svc.data.id]);
+
+      const audit = queryAuditLog({ resourceType: 'service' });
+      expect(audit.ok).toBe(true);
+      if (!audit.ok) return;
+      expect(audit.data.entries).toHaveLength(2);
+      expect(audit.data.entries.every(e => e.resourceType === 'service')).toBe(true);
+    });
+  });
+
+  // ── Edge Cases ──
+
+  describe('Edge cases', () => {
+    it('should handle empty results correctly after all services are deleted', () => {
+      const services = makeServices(3);
+      const createResult = bulkCreateServices(services);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      const ids = createResult.data.results.map(r => r.data!.id);
+      const deleteResult = bulkDeleteServices(ids);
+      expect(deleteResult.ok).toBe(true);
+      if (!deleteResult.ok) return;
+
+      const listed = listServices();
+      expect(listed.ok).toBe(true);
+      if (!listed.ok) return;
+      expect(listed.data).toHaveLength(0);
+    });
+
+    it('should handle bulk update with no actual changes', () => {
+      const svc = createService(makeService({ name: 'No Change' }));
+      expect(svc.ok).toBe(true);
+      if (!svc.ok) return;
+
+      // Update with the same values
+      const result = bulkUpdateServices([
+        { id: svc.data.id, name: 'No Change' },
+      ]);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.succeeded).toBe(1);
+      expect(result.data.results[0].data?.name).toBe('No Change');
+    });
+
+    it('should handle bulk operations with a single item', () => {
+      const createResult = bulkCreateServices([makeService({ name: 'Singleton' })]);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+      expect(createResult.data.total).toBe(1);
+
+      const id = createResult.data.results[0].data!.id;
+
+      const updateResult = bulkUpdateServices([{ id, name: 'Updated Singleton' }]);
+      expect(updateResult.ok).toBe(true);
+      if (!updateResult.ok) return;
+      expect(updateResult.data.total).toBe(1);
+
+      const deleteResult = bulkDeleteServices([id]);
+      expect(deleteResult.ok).toBe(true);
+      if (!deleteResult.ok) return;
+      expect(deleteResult.data.total).toBe(1);
+    });
+
+    it('should handle atomic delete of all non-existent IDs', () => {
+      const result = bulkDeleteServices([
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000002',
+      ], 'atomic');
+
+      expect(result.ok).toBe(false);
+    });
+
+    it('should handle partial delete of all non-existent IDs', () => {
+      const result = bulkDeleteServices([
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000002',
+      ], 'partial');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.ok).toBe(false);
+      expect(result.data.succeeded).toBe(0);
+      expect(result.data.failed).toBe(2);
+    });
+
+    it('should handle mixed success and failure in partial update of many items', () => {
+      const svcs = makeServices(5).map(s => createService(s));
+      const validIds = svcs.map(r => {
+        expect(r.ok).toBe(true);
+        if (!r.ok) throw new Error('Setup failed');
+        return r.data.id;
+      });
+
+      // Mix valid and invalid IDs
+      const updates = [
+        { id: validIds[0], name: 'OK 1' },
+        { id: '00000000-0000-0000-0000-000000000001', name: 'Fail 1' },
+        { id: validIds[2], name: 'OK 2' },
+        { id: '00000000-0000-0000-0000-000000000002', name: 'Fail 2' },
+        { id: validIds[4], name: 'OK 3' },
+      ];
+
+      const result = bulkUpdateServices(updates, 'partial');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.succeeded).toBe(3);
+      expect(result.data.failed).toBe(2);
+      expect(result.data.results[0].ok).toBe(true);
+      expect(result.data.results[1].ok).toBe(false);
+      expect(result.data.results[2].ok).toBe(true);
+      expect(result.data.results[3].ok).toBe(false);
+      expect(result.data.results[4].ok).toBe(true);
+    });
+  });
+});

--- a/tests/cache-middleware.test.ts
+++ b/tests/cache-middleware.test.ts
@@ -1,0 +1,711 @@
+/**
+ * Cache Middleware Tests
+ *
+ * Tests for HTTP response caching with ETag, Last-Modified,
+ * LRU eviction, TTL expiry, cache invalidation, and stats.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express, { type Request, type Response } from 'express';
+import request from 'supertest';
+import {
+  cacheMiddleware,
+  generateETag,
+  invalidateCache,
+  getCacheStats,
+  resetCache,
+} from '../src/api/cache-middleware.js';
+
+// Mock the logger to suppress output in tests
+vi.mock('../src/core/logger.js', () => ({
+  createChildLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  }),
+  getLogger: () => ({
+    level: 'error',
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+// Mock config (required by logger import chain)
+vi.mock('../src/core/config.js', () => ({
+  getConfig: () => ({
+    logLevel: 'error',
+    dbPath: ':memory:',
+    port: 3000,
+    siteName: 'StatusOwl',
+    siteDescription: '',
+    primaryColor: '#4f46e5',
+    accentColor: '#10b981',
+  }),
+  loadConfig: vi.fn(),
+}));
+
+/**
+ * Helper: create a fresh Express app with the cache middleware
+ * and a test endpoint.
+ */
+function createTestApp(
+  options: Parameters<typeof cacheMiddleware>[0] = {},
+  responseData: Record<string, unknown> = { ok: true, data: { id: '1', name: 'Test' } },
+  statusCode = 200,
+): ReturnType<typeof express> {
+  const app = express();
+  app.use(express.json());
+  app.use(cacheMiddleware(options));
+
+  // GET endpoint
+  app.get('/api/services', (_req: Request, res: Response) => {
+    res.status(statusCode).json(responseData);
+  });
+
+  app.get('/api/services/:id', (req: Request, res: Response) => {
+    res.status(statusCode).json({ ok: true, data: { id: req.params.id, name: 'Service' } });
+  });
+
+  app.get('/api/groups', (_req: Request, res: Response) => {
+    res.status(statusCode).json({ ok: true, data: [{ id: 'g1', name: 'Group 1' }] });
+  });
+
+  // Mutation endpoints
+  app.post('/api/services', (req: Request, res: Response) => {
+    res.status(201).json({ ok: true, data: { id: 'new-1', ...req.body } });
+  });
+
+  app.patch('/api/services/:id', (req: Request, res: Response) => {
+    res.status(200).json({ ok: true, data: { id: req.params.id, ...req.body } });
+  });
+
+  app.delete('/api/services/:id', (req: Request, res: Response) => {
+    res.status(200).json({ ok: true, data: { deleted: true } });
+  });
+
+  // Error endpoint (4xx should not be cached)
+  app.get('/api/error', (_req: Request, res: Response) => {
+    res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Not found' } });
+  });
+
+  return app;
+}
+
+describe('Cache Middleware', () => {
+  beforeEach(() => {
+    resetCache();
+  });
+
+  afterEach(() => {
+    resetCache();
+  });
+
+  // ── ETag Generation ──
+
+  describe('generateETag', () => {
+    it('should produce a weak ETag string from body content', () => {
+      const body = JSON.stringify({ ok: true, data: 'hello' });
+      const etag = generateETag(body);
+
+      expect(etag).toMatch(/^W\/"[a-f0-9]{32}"$/);
+    });
+
+    it('should produce the same ETag for the same body', () => {
+      const body = JSON.stringify({ ok: true, data: [1, 2, 3] });
+      const etag1 = generateETag(body);
+      const etag2 = generateETag(body);
+
+      expect(etag1).toBe(etag2);
+    });
+
+    it('should produce different ETags for different bodies', () => {
+      const etag1 = generateETag('{"a":1}');
+      const etag2 = generateETag('{"a":2}');
+
+      expect(etag1).not.toBe(etag2);
+    });
+
+    it('should handle empty string body', () => {
+      const etag = generateETag('');
+      expect(etag).toMatch(/^W\/"[a-f0-9]{32}"$/);
+    });
+  });
+
+  // ── Basic Caching Behavior ──
+
+  describe('basic caching', () => {
+    it('should set ETag, Last-Modified, Cache-Control on first request (cache miss)', async () => {
+      const app = createTestApp();
+
+      const res = await request(app).get('/api/services');
+
+      expect(res.status).toBe(200);
+      expect(res.headers['etag']).toMatch(/^W\/"[a-f0-9]{32}"$/);
+      expect(res.headers['last-modified']).toBeDefined();
+      expect(res.headers['cache-control']).toBe('public, max-age=60');
+      expect(res.headers['x-cache']).toBe('MISS');
+    });
+
+    it('should return X-Cache: HIT on second request for same URL', async () => {
+      const app = createTestApp();
+
+      // First request: cache miss
+      await request(app).get('/api/services');
+
+      // Second request: cache hit
+      const res = await request(app).get('/api/services');
+
+      expect(res.status).toBe(200);
+      expect(res.headers['x-cache']).toBe('HIT');
+      expect(res.headers['etag']).toBeDefined();
+      expect(res.headers['last-modified']).toBeDefined();
+    });
+
+    it('should use custom Cache-Control header when specified', async () => {
+      const app = createTestApp({ cacheControl: 'private, max-age=300' });
+
+      const res = await request(app).get('/api/services');
+
+      expect(res.headers['cache-control']).toBe('private, max-age=300');
+    });
+
+    it('should not cache non-2xx responses', async () => {
+      const app = createTestApp({}, { ok: true, data: 'test' }, 200);
+
+      // Request to error endpoint
+      const res1 = await request(app).get('/api/error');
+      expect(res1.status).toBe(404);
+
+      // Stats should show no entries cached for the error
+      const stats = getCacheStats();
+      // Only the error request happened, and it should not be cached
+      // (misses counter may be 0 because the response is captured but not stored)
+      expect(stats.size).toBe(0);
+    });
+
+    it('should cache different URLs independently', async () => {
+      const app = createTestApp();
+
+      await request(app).get('/api/services');
+      await request(app).get('/api/groups');
+
+      const stats = getCacheStats();
+      expect(stats.size).toBe(2);
+    });
+
+    it('should return the same response body on cache hit', async () => {
+      const responseData = { ok: true, data: { id: '1', name: 'Cached Service' } };
+      const app = createTestApp({}, responseData);
+
+      const res1 = await request(app).get('/api/services');
+      const res2 = await request(app).get('/api/services');
+
+      expect(res1.body).toEqual(responseData);
+      expect(res2.body).toEqual(responseData);
+    });
+  });
+
+  // ── 304 Not Modified (If-None-Match) ──
+
+  describe('conditional requests — If-None-Match', () => {
+    it('should return 304 when If-None-Match matches the cached ETag', async () => {
+      const app = createTestApp();
+
+      // Prime the cache
+      const first = await request(app).get('/api/services');
+      const etag = first.headers['etag'];
+
+      // Conditional request
+      const res = await request(app)
+        .get('/api/services')
+        .set('If-None-Match', etag);
+
+      expect(res.status).toBe(304);
+      expect(res.body).toEqual({});
+    });
+
+    it('should return 200 when If-None-Match does not match', async () => {
+      const app = createTestApp();
+
+      // Prime the cache
+      await request(app).get('/api/services');
+
+      // Conditional request with wrong ETag
+      const res = await request(app)
+        .get('/api/services')
+        .set('If-None-Match', 'W/"0000000000000000"');
+
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 200 on first request even with If-None-Match header', async () => {
+      const app = createTestApp();
+
+      // Send If-None-Match without priming (no cache entry)
+      const res = await request(app)
+        .get('/api/services')
+        .set('If-None-Match', 'W/"anything"');
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── 304 Not Modified (If-Modified-Since) ──
+
+  describe('conditional requests — If-Modified-Since', () => {
+    it('should return 304 when If-Modified-Since is after Last-Modified', async () => {
+      const app = createTestApp();
+
+      // Prime the cache
+      const first = await request(app).get('/api/services');
+      const lastModified = first.headers['last-modified'];
+
+      // Use a date in the future
+      const futureDate = new Date(Date.now() + 60_000).toUTCString();
+
+      const res = await request(app)
+        .get('/api/services')
+        .set('If-Modified-Since', futureDate);
+
+      expect(res.status).toBe(304);
+    });
+
+    it('should return 304 when If-Modified-Since equals Last-Modified', async () => {
+      const app = createTestApp();
+
+      // Prime the cache
+      const first = await request(app).get('/api/services');
+      const lastModified = first.headers['last-modified'];
+
+      const res = await request(app)
+        .get('/api/services')
+        .set('If-Modified-Since', lastModified);
+
+      expect(res.status).toBe(304);
+    });
+
+    it('should return 200 when If-Modified-Since is before Last-Modified', async () => {
+      const app = createTestApp();
+
+      // Prime the cache
+      await request(app).get('/api/services');
+
+      // Use a date far in the past
+      const pastDate = new Date('2020-01-01').toUTCString();
+
+      const res = await request(app)
+        .get('/api/services')
+        .set('If-Modified-Since', pastDate);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('should ignore invalid If-Modified-Since dates', async () => {
+      const app = createTestApp();
+
+      // Prime the cache
+      await request(app).get('/api/services');
+
+      const res = await request(app)
+        .get('/api/services')
+        .set('If-Modified-Since', 'not-a-date');
+
+      // Invalid date should not trigger 304, should serve from cache
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── If-None-Match takes precedence over If-Modified-Since ──
+
+  describe('conditional request precedence', () => {
+    it('should check If-None-Match before If-Modified-Since', async () => {
+      const app = createTestApp();
+
+      // Prime the cache
+      const first = await request(app).get('/api/services');
+      const etag = first.headers['etag'];
+
+      // Both headers present, ETag matches -> 304 regardless of date
+      const res = await request(app)
+        .get('/api/services')
+        .set('If-None-Match', etag)
+        .set('If-Modified-Since', 'Mon, 01 Jan 2020 00:00:00 GMT');
+
+      expect(res.status).toBe(304);
+    });
+  });
+
+  // ── LRU Eviction ──
+
+  describe('LRU eviction', () => {
+    it('should evict the least-recently-used entry when cache is full', async () => {
+      const app = createTestApp({ maxEntries: 3 });
+
+      // Fill cache to capacity
+      await request(app).get('/api/services');
+      await request(app).get('/api/services/1');
+      await request(app).get('/api/services/2');
+
+      const statsBefore = getCacheStats();
+      expect(statsBefore.size).toBe(3);
+
+      // One more should evict the oldest (GET:/api/services)
+      await request(app).get('/api/groups');
+
+      const statsAfter = getCacheStats();
+      expect(statsAfter.size).toBe(3);
+      expect(statsAfter.evictions).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should keep most-recently-used entries on eviction', async () => {
+      const app = createTestApp({ maxEntries: 2 });
+
+      // Add two entries
+      await request(app).get('/api/services');
+      await request(app).get('/api/services/1');
+
+      // Access the first one again (promotes it)
+      await request(app).get('/api/services');
+
+      // Add a third — should evict /api/services/1 (LRU)
+      await request(app).get('/api/groups');
+
+      // /api/services should still be cached (was promoted)
+      const res = await request(app).get('/api/services');
+      expect(res.headers['x-cache']).toBe('HIT');
+
+      // /api/services/1 should have been evicted
+      const res2 = await request(app).get('/api/services/1');
+      expect(res2.headers['x-cache']).toBe('MISS');
+    });
+
+    it('should respect maxEntries of 1', async () => {
+      const app = createTestApp({ maxEntries: 1 });
+
+      await request(app).get('/api/services');
+      expect(getCacheStats().size).toBe(1);
+
+      await request(app).get('/api/groups');
+      expect(getCacheStats().size).toBe(1);
+      expect(getCacheStats().evictions).toBe(1);
+    });
+  });
+
+  // ── TTL Expiry ──
+
+  describe('TTL expiry', () => {
+    it('should expire cache entries after TTL', async () => {
+      // Use a very short TTL
+      const app = createTestApp({ defaultTtlSeconds: 1 });
+
+      // Prime the cache
+      await request(app).get('/api/services');
+      expect(getCacheStats().size).toBe(1);
+
+      // Manually mock Date.now to simulate time passing
+      const realDateNow = Date.now;
+      try {
+        const baseTime = Date.now();
+        vi.spyOn(Date, 'now').mockReturnValue(baseTime + 2000); // 2 seconds later
+
+        // This should be a miss because the entry expired
+        const res = await request(app).get('/api/services');
+        expect(res.headers['x-cache']).toBe('MISS');
+      } finally {
+        vi.restoreAllMocks();
+      }
+    });
+
+    it('should serve from cache before TTL expires', async () => {
+      const app = createTestApp({ defaultTtlSeconds: 3600 }); // 1 hour
+
+      await request(app).get('/api/services');
+
+      // Advance time by 30 minutes (still within TTL)
+      const realDateNow = Date.now;
+      try {
+        const baseTime = Date.now();
+        vi.spyOn(Date, 'now').mockReturnValue(baseTime + 30 * 60 * 1000);
+
+        const res = await request(app).get('/api/services');
+        expect(res.headers['x-cache']).toBe('HIT');
+      } finally {
+        vi.restoreAllMocks();
+      }
+    });
+  });
+
+  // ── Cache Invalidation on Mutations ──
+
+  describe('cache invalidation on mutations', () => {
+    it('should invalidate cache when POST request hits the same route prefix', async () => {
+      const app = createTestApp();
+
+      // Prime cache
+      await request(app).get('/api/services');
+      expect(getCacheStats().size).toBe(1);
+
+      // POST to /api/services should invalidate the cached GET
+      await request(app)
+        .post('/api/services')
+        .send({ name: 'New Service', url: 'https://example.com' });
+
+      // GET should be a miss now
+      const res = await request(app).get('/api/services');
+      expect(res.headers['x-cache']).toBe('MISS');
+    });
+
+    it('should invalidate cache when PATCH request hits a related route', async () => {
+      const app = createTestApp();
+
+      // Prime cache
+      await request(app).get('/api/services');
+      expect(getCacheStats().size).toBe(1);
+
+      // PATCH to /api/services/123 should invalidate /api/services
+      await request(app)
+        .patch('/api/services/abc-def')
+        .send({ name: 'Updated' });
+
+      const res = await request(app).get('/api/services');
+      expect(res.headers['x-cache']).toBe('MISS');
+    });
+
+    it('should invalidate cache when DELETE request hits a related route', async () => {
+      const app = createTestApp();
+
+      // Prime cache
+      await request(app).get('/api/services');
+
+      // DELETE /api/services/123
+      await request(app).delete('/api/services/some-id');
+
+      const res = await request(app).get('/api/services');
+      expect(res.headers['x-cache']).toBe('MISS');
+    });
+
+    it('should not invalidate unrelated routes on mutation', async () => {
+      const app = createTestApp();
+
+      // Prime cache for both routes
+      await request(app).get('/api/services');
+      await request(app).get('/api/groups');
+      expect(getCacheStats().size).toBe(2);
+
+      // POST to /api/services should NOT invalidate /api/groups
+      await request(app)
+        .post('/api/services')
+        .send({ name: 'New' });
+
+      const res = await request(app).get('/api/groups');
+      expect(res.headers['x-cache']).toBe('HIT');
+    });
+  });
+
+  // ── Invalidation Groups ──
+
+  describe('invalidation groups', () => {
+    it('should invalidate all routes in the same group on mutation', async () => {
+      const app = createTestApp({
+        invalidationGroups: {
+          catalog: ['/api/services', '/api/groups'],
+        },
+      });
+
+      // Prime cache for both routes
+      await request(app).get('/api/services');
+      await request(app).get('/api/groups');
+      expect(getCacheStats().size).toBe(2);
+
+      // POST to /api/services should also invalidate /api/groups (same group)
+      await request(app)
+        .post('/api/services')
+        .send({ name: 'New' });
+
+      const resServices = await request(app).get('/api/services');
+      const resGroups = await request(app).get('/api/groups');
+
+      expect(resServices.headers['x-cache']).toBe('MISS');
+      expect(resGroups.headers['x-cache']).toBe('MISS');
+    });
+  });
+
+  // ── Manual Invalidation via invalidateCache() ──
+
+  describe('invalidateCache()', () => {
+    it('should invalidate entries matching the given pattern', async () => {
+      const app = createTestApp();
+
+      await request(app).get('/api/services');
+      await request(app).get('/api/groups');
+      expect(getCacheStats().size).toBe(2);
+
+      const count = invalidateCache('/api/services');
+      expect(count).toBeGreaterThanOrEqual(1);
+      expect(getCacheStats().size).toBe(1);
+    });
+
+    it('should return 0 when no entries match the pattern', () => {
+      const count = invalidateCache('/api/nonexistent');
+      expect(count).toBe(0);
+    });
+  });
+
+  // ── Cache Stats ──
+
+  describe('getCacheStats()', () => {
+    it('should report accurate size, hits, and misses', async () => {
+      const app = createTestApp();
+
+      // 1 miss
+      await request(app).get('/api/services');
+
+      // 1 hit
+      await request(app).get('/api/services');
+
+      const stats = getCacheStats();
+      expect(stats.size).toBe(1);
+      expect(stats.hits).toBeGreaterThanOrEqual(1);
+      expect(stats.misses).toBeGreaterThanOrEqual(1);
+      expect(stats.maxEntries).toBe(500);
+    });
+
+    it('should report eviction count', async () => {
+      const app = createTestApp({ maxEntries: 1 });
+
+      await request(app).get('/api/services');
+      await request(app).get('/api/groups'); // evicts /api/services
+
+      const stats = getCacheStats();
+      expect(stats.evictions).toBe(1);
+    });
+
+    it('should report invalidation count', async () => {
+      const app = createTestApp();
+
+      await request(app).get('/api/services');
+      invalidateCache('/api/services');
+
+      const stats = getCacheStats();
+      expect(stats.invalidations).toBe(1);
+    });
+
+    it('should report hit rate correctly', async () => {
+      const app = createTestApp();
+
+      // 1 miss + 3 hits = 75% hit rate
+      await request(app).get('/api/services');
+      await request(app).get('/api/services');
+      await request(app).get('/api/services');
+      await request(app).get('/api/services');
+
+      const stats = getCacheStats();
+      expect(stats.hitRate).toBe(75);
+    });
+
+    it('should report 0 hit rate when no requests made', () => {
+      // Initialize cache by creating app with middleware
+      createTestApp();
+      const stats = getCacheStats();
+      expect(stats.hitRate).toBe(0);
+      expect(stats.size).toBe(0);
+    });
+  });
+
+  // ── Edge Cases ──
+
+  describe('edge cases', () => {
+    it('should handle requests with query strings as separate cache keys', async () => {
+      const app = createTestApp();
+
+      await request(app).get('/api/services?limit=10');
+      await request(app).get('/api/services?limit=20');
+
+      expect(getCacheStats().size).toBe(2);
+    });
+
+    it('should not cache HEAD requests', async () => {
+      const app = createTestApp();
+
+      await request(app).head('/api/services');
+
+      expect(getCacheStats().size).toBe(0);
+    });
+
+    it('should pass through PUT requests without caching', async () => {
+      const app = express();
+      app.use(express.json());
+      app.use(cacheMiddleware());
+
+      app.put('/api/services/:id', (req: Request, res: Response) => {
+        res.json({ ok: true, data: { updated: true } });
+      });
+
+      const res = await request(app)
+        .put('/api/services/1')
+        .send({ name: 'Updated' });
+
+      expect(res.status).toBe(200);
+      expect(getCacheStats().size).toBe(0);
+    });
+
+    it('should update cached entry when same URL is fetched after invalidation', async () => {
+      let callCount = 0;
+      const app = express();
+      app.use(express.json());
+      app.use(cacheMiddleware());
+
+      app.get('/api/counter', (_req: Request, res: Response) => {
+        callCount++;
+        res.json({ ok: true, data: { count: callCount } });
+      });
+
+      app.post('/api/counter', (_req: Request, res: Response) => {
+        res.status(201).json({ ok: true });
+      });
+
+      // First request: callCount = 1
+      const res1 = await request(app).get('/api/counter');
+      expect(res1.body.data.count).toBe(1);
+
+      // Second request: served from cache, still 1
+      const res2 = await request(app).get('/api/counter');
+      expect(res2.body.data.count).toBe(1);
+      expect(res2.headers['x-cache']).toBe('HIT');
+
+      // Mutation invalidates
+      await request(app).post('/api/counter').send({});
+
+      // Third request: cache miss, handler runs again, callCount = 2
+      const res3 = await request(app).get('/api/counter');
+      expect(res3.body.data.count).toBe(2);
+      expect(res3.headers['x-cache']).toBe('MISS');
+    });
+  });
+
+  // ── resetCache() ──
+
+  describe('resetCache()', () => {
+    it('should clear all entries and reset state', async () => {
+      const app = createTestApp();
+
+      await request(app).get('/api/services');
+      await request(app).get('/api/groups');
+      expect(getCacheStats().size).toBe(2);
+
+      resetCache();
+
+      // After reset, getCacheStats initializes a fresh cache
+      const stats = getCacheStats();
+      expect(stats.size).toBe(0);
+      expect(stats.hits).toBe(0);
+      expect(stats.misses).toBe(0);
+    });
+  });
+});

--- a/tests/composite-service.test.ts
+++ b/tests/composite-service.test.ts
@@ -1,0 +1,862 @@
+/**
+ * Composite Service Tests
+ *
+ * Tests for composite service creation, child management, all three
+ * derivation rules (worst-case, majority, weighted), cycle detection,
+ * nested composites, and status computation accuracy.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
+import {
+  createCompositeService,
+  addChild,
+  removeChild,
+  getChildren,
+  computeStatus,
+} from '../src/monitors/composite-service.js';
+import { createService, updateServiceStatus, getService } from '../src/storage/service-repo.js';
+import { getDb, closeDb } from '../src/storage/database.js';
+import type { CreateService, ServiceStatus } from '../src/core/index.js';
+
+describe('Composite Service', () => {
+  let db: ReturnType<typeof getDb>;
+
+  /** Helper to create a regular service and return its ID. */
+  function makeService(name: string, status: ServiceStatus = 'operational'): string {
+    const input: CreateService = {
+      name,
+      url: `https://${name.toLowerCase().replace(/\s+/g, '-')}.example.com`,
+    };
+    const result = createService(input);
+    if (!result.ok) throw new Error(`Failed to create service: ${result.error.message}`);
+
+    // Set the desired status
+    updateServiceStatus(result.data.id, status);
+    return result.data.id;
+  }
+
+  beforeAll(() => {
+    process.env.DB_PATH = ':memory:';
+    process.env.LOG_LEVEL = 'error';
+    db = getDb();
+  });
+
+  afterAll(() => {
+    closeDb();
+  });
+
+  beforeEach(() => {
+    // Clear all tables that might have FK constraints or test data
+    db.prepare('DELETE FROM composite_children').run();
+    db.prepare('DELETE FROM service_dependencies').run();
+    db.prepare('DELETE FROM incident_updates').run();
+    db.prepare('DELETE FROM incident_services').run();
+    db.prepare('DELETE FROM incidents').run();
+    db.prepare('DELETE FROM check_results').run();
+    db.prepare('DELETE FROM services').run();
+    db.prepare('DELETE FROM service_groups').run();
+  });
+
+  // ── createCompositeService ──
+
+  describe('createCompositeService', () => {
+    it('should create a composite service with children', () => {
+      const childA = makeService('Child A');
+      const childB = makeService('Child B');
+
+      const result = createCompositeService('My Composite', [childA, childB]);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.name).toBe('My Composite');
+      expect(result.data.checkType).toBe('composite');
+      expect(result.data.id).toBeDefined();
+    });
+
+    it('should create a composite with no children', () => {
+      const result = createCompositeService('Empty Composite', []);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.checkType).toBe('composite');
+
+      // Verify no children
+      const children = getChildren(result.data.id);
+      expect(children.ok).toBe(true);
+      if (!children.ok) return;
+      expect(children.data.length).toBe(0);
+    });
+
+    it('should create a composite with a specific derivation rule', () => {
+      const child = makeService('Child');
+
+      const result = createCompositeService('Weighted Composite', [child], 'weighted');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const children = getChildren(result.data.id);
+      expect(children.ok).toBe(true);
+      if (!children.ok) return;
+      expect(children.data.length).toBe(1);
+      expect(children.data[0].derivationRule).toBe('weighted');
+    });
+
+    it('should reject duplicate child IDs in creation', () => {
+      const child = makeService('Child');
+
+      const result = createCompositeService('Dup Composite', [child, child]);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('VALIDATION');
+      expect(result.error.message).toContain('Duplicate');
+    });
+
+    it('should reject non-existent child IDs', () => {
+      const result = createCompositeService('Bad Composite', ['00000000-0000-0000-0000-000000000000']);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+
+    it('should default to worst-case derivation rule', () => {
+      const child = makeService('Child');
+
+      const result = createCompositeService('Default Rule', [child]);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const children = getChildren(result.data.id);
+      expect(children.ok).toBe(true);
+      if (!children.ok) return;
+      expect(children.data[0].derivationRule).toBe('worst-case');
+    });
+  });
+
+  // ── addChild ──
+
+  describe('addChild', () => {
+    it('should add a child to an existing composite', () => {
+      const compositeResult = createCompositeService('Composite', []);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const child = makeService('New Child');
+      const result = addChild(compositeResult.data.id, child);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.compositeId).toBe(compositeResult.data.id);
+      expect(result.data.childId).toBe(child);
+      expect(result.data.weight).toBe(1.0);
+    });
+
+    it('should add a child with a custom weight', () => {
+      const compositeResult = createCompositeService('Composite', []);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const child = makeService('Weighted Child');
+      const result = addChild(compositeResult.data.id, child, 3.5);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.weight).toBe(3.5);
+    });
+
+    it('should reject adding to a non-composite service', () => {
+      const regular = makeService('Regular Service');
+      const child = makeService('Child');
+
+      const result = addChild(regular, child);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('VALIDATION');
+      expect(result.error.message).toContain('not a composite');
+    });
+
+    it('should reject self-reference', () => {
+      const compositeResult = createCompositeService('Composite', []);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const result = addChild(compositeResult.data.id, compositeResult.data.id);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('VALIDATION');
+      expect(result.error.message).toContain('itself');
+    });
+
+    it('should reject duplicate children', () => {
+      const compositeResult = createCompositeService('Composite', []);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const child = makeService('Child');
+      const first = addChild(compositeResult.data.id, child);
+      expect(first.ok).toBe(true);
+
+      const duplicate = addChild(compositeResult.data.id, child);
+      expect(duplicate.ok).toBe(false);
+      if (duplicate.ok) return;
+      expect(duplicate.error.code).toBe('DUPLICATE');
+    });
+
+    it('should reject non-existent composite ID', () => {
+      const child = makeService('Child');
+      const result = addChild('00000000-0000-0000-0000-000000000000', child);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+
+    it('should reject non-existent child ID', () => {
+      const compositeResult = createCompositeService('Composite', []);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const result = addChild(compositeResult.data.id, '00000000-0000-0000-0000-000000000000');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+
+    it('should reject zero or negative weight', () => {
+      const compositeResult = createCompositeService('Composite', []);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const child = makeService('Child');
+      const result = addChild(compositeResult.data.id, child, 0);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('VALIDATION');
+      expect(result.error.message).toContain('Weight');
+    });
+  });
+
+  // ── removeChild ──
+
+  describe('removeChild', () => {
+    it('should remove an existing child', () => {
+      const child = makeService('Child');
+      const compositeResult = createCompositeService('Composite', [child]);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const result = removeChild(compositeResult.data.id, child);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.removed).toBe(true);
+
+      // Verify child is gone
+      const children = getChildren(compositeResult.data.id);
+      expect(children.ok).toBe(true);
+      if (!children.ok) return;
+      expect(children.data.length).toBe(0);
+    });
+
+    it('should return NOT_FOUND for a child that is not in the composite', () => {
+      const compositeResult = createCompositeService('Composite', []);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const result = removeChild(compositeResult.data.id, '00000000-0000-0000-0000-000000000000');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+
+    it('should only remove the specified child, not others', () => {
+      const childA = makeService('Child A');
+      const childB = makeService('Child B');
+      const compositeResult = createCompositeService('Composite', [childA, childB]);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      removeChild(compositeResult.data.id, childA);
+
+      const children = getChildren(compositeResult.data.id);
+      expect(children.ok).toBe(true);
+      if (!children.ok) return;
+      expect(children.data.length).toBe(1);
+      expect(children.data[0].childId).toBe(childB);
+    });
+  });
+
+  // ── getChildren ──
+
+  describe('getChildren', () => {
+    it('should return all children with weights', () => {
+      const childA = makeService('Child A');
+      const childB = makeService('Child B');
+      const compositeResult = createCompositeService('Composite', [childA, childB]);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const result = getChildren(compositeResult.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(2);
+
+      const childIds = result.data.map((c) => c.childId);
+      expect(childIds).toContain(childA);
+      expect(childIds).toContain(childB);
+
+      // Default weight is 1.0
+      for (const child of result.data) {
+        expect(child.weight).toBe(1.0);
+      }
+    });
+
+    it('should return empty array for composite with no children', () => {
+      const compositeResult = createCompositeService('Empty', []);
+      expect(compositeResult.ok).toBe(true);
+      if (!compositeResult.ok) return;
+
+      const result = getChildren(compositeResult.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(0);
+    });
+
+    it('should return empty array for a non-existent composite', () => {
+      const result = getChildren('00000000-0000-0000-0000-000000000000');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(0);
+    });
+  });
+
+  // ── Cycle detection ──
+
+  describe('cycle detection', () => {
+    it('should reject direct cycle: composite A contains composite B, B tries to contain A', () => {
+      const child = makeService('Leaf');
+
+      const compositeA = createCompositeService('Composite A', [child]);
+      expect(compositeA.ok).toBe(true);
+      if (!compositeA.ok) return;
+
+      const compositeB = createCompositeService('Composite B', [compositeA.data.id]);
+      expect(compositeB.ok).toBe(true);
+      if (!compositeB.ok) return;
+
+      // Try to add A as child of B's existing composite — but B already contains A
+      // Actually: B contains A.id. Now try to add B.id as child of A => A -> B -> A cycle
+      const result = addChild(compositeA.data.id, compositeB.data.id);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('VALIDATION');
+      expect(result.error.message).toContain('circular');
+    });
+
+    it('should reject transitive cycle: A -> B -> C, then C -> A', () => {
+      const leaf = makeService('Leaf');
+
+      const compositeC = createCompositeService('Composite C', [leaf]);
+      expect(compositeC.ok).toBe(true);
+      if (!compositeC.ok) return;
+
+      const compositeB = createCompositeService('Composite B', [compositeC.data.id]);
+      expect(compositeB.ok).toBe(true);
+      if (!compositeB.ok) return;
+
+      const compositeA = createCompositeService('Composite A', [compositeB.data.id]);
+      expect(compositeA.ok).toBe(true);
+      if (!compositeA.ok) return;
+
+      // Try to add A as child of C => C -> A -> B -> C cycle
+      const result = addChild(compositeC.data.id, compositeA.data.id);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('VALIDATION');
+      expect(result.error.message).toContain('circular');
+    });
+
+    it('should allow non-circular hierarchies', () => {
+      const childA = makeService('Child A');
+      const childB = makeService('Child B');
+      const childC = makeService('Child C');
+
+      // A contains childA, B contains childB, C contains childC
+      const compositeA = createCompositeService('Composite A', [childA]);
+      expect(compositeA.ok).toBe(true);
+      if (!compositeA.ok) return;
+
+      const compositeB = createCompositeService('Composite B', [childB]);
+      expect(compositeB.ok).toBe(true);
+      if (!compositeB.ok) return;
+
+      // Parent that contains both A and B (no cycle)
+      const compositeParent = createCompositeService('Parent', [compositeA.data.id, compositeB.data.id]);
+      expect(compositeParent.ok).toBe(true);
+    });
+  });
+
+  // ── Nested composites ──
+
+  describe('nested composites', () => {
+    it('should support composite containing other composites', () => {
+      const leaf1 = makeService('Leaf 1');
+      const leaf2 = makeService('Leaf 2');
+      const leaf3 = makeService('Leaf 3');
+
+      const innerA = createCompositeService('Inner A', [leaf1, leaf2]);
+      expect(innerA.ok).toBe(true);
+      if (!innerA.ok) return;
+
+      const innerB = createCompositeService('Inner B', [leaf3]);
+      expect(innerB.ok).toBe(true);
+      if (!innerB.ok) return;
+
+      const outer = createCompositeService('Outer', [innerA.data.id, innerB.data.id]);
+      expect(outer.ok).toBe(true);
+      if (!outer.ok) return;
+
+      const children = getChildren(outer.data.id);
+      expect(children.ok).toBe(true);
+      if (!children.ok) return;
+      expect(children.data.length).toBe(2);
+    });
+
+    it('should compute nested composite status recursively', () => {
+      // Inner composite: leaf1 (operational) + leaf2 (major_outage) => worst-case = major_outage
+      const leaf1 = makeService('Leaf 1', 'operational');
+      const leaf2 = makeService('Leaf 2', 'major_outage');
+
+      const inner = createCompositeService('Inner', [leaf1, leaf2], 'worst-case');
+      expect(inner.ok).toBe(true);
+      if (!inner.ok) return;
+
+      // Compute inner status first
+      const innerStatus = computeStatus(inner.data.id);
+      expect(innerStatus.ok).toBe(true);
+      if (!innerStatus.ok) return;
+      expect(innerStatus.data).toBe('major_outage');
+
+      // Outer composite: inner (now major_outage) + leaf3 (operational) => worst-case = major_outage
+      const leaf3 = makeService('Leaf 3', 'operational');
+      const outer = createCompositeService('Outer', [inner.data.id, leaf3], 'worst-case');
+      expect(outer.ok).toBe(true);
+      if (!outer.ok) return;
+
+      const outerStatus = computeStatus(outer.data.id);
+      expect(outerStatus.ok).toBe(true);
+      if (!outerStatus.ok) return;
+      expect(outerStatus.data).toBe('major_outage');
+    });
+  });
+
+  // ── computeStatus: worst-case ──
+
+  describe('computeStatus — worst-case', () => {
+    it('should return operational when all children are operational', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'operational');
+      const childC = makeService('C', 'operational');
+
+      const composite = createCompositeService('Composite', [childA, childB, childC], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('operational');
+    });
+
+    it('should return degraded when any child is degraded and none are worse', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'degraded');
+      const childC = makeService('C', 'operational');
+
+      const composite = createCompositeService('Composite', [childA, childB, childC], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('degraded');
+    });
+
+    it('should return major_outage when any child is in major_outage', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'degraded');
+      const childC = makeService('C', 'major_outage');
+
+      const composite = createCompositeService('Composite', [childA, childB, childC], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('major_outage');
+    });
+
+    it('should return unknown for a composite with no children', () => {
+      const composite = createCompositeService('Empty', [], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('unknown');
+    });
+
+    it('should persist the computed status to the database', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'degraded');
+
+      const composite = createCompositeService('Composite', [childA, childB], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      computeStatus(composite.data.id);
+
+      // Re-read the service from DB
+      const service = getService(composite.data.id);
+      expect(service.ok).toBe(true);
+      if (!service.ok) return;
+      expect(service.data.status).toBe('degraded');
+    });
+
+    it('should pick partial_outage over degraded', () => {
+      const childA = makeService('A', 'degraded');
+      const childB = makeService('B', 'partial_outage');
+
+      const composite = createCompositeService('Composite', [childA, childB], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('partial_outage');
+    });
+
+    it('should handle maintenance status as worst', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'maintenance');
+
+      const composite = createCompositeService('Composite', [childA, childB], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('maintenance');
+    });
+  });
+
+  // ── computeStatus: majority ──
+
+  describe('computeStatus — majority', () => {
+    it('should return the status held by more than 50% of children', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'operational');
+      const childC = makeService('C', 'degraded');
+
+      const composite = createCompositeService('Composite', [childA, childB, childC], 'majority');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('operational');
+    });
+
+    it('should return degraded when majority of children are degraded', () => {
+      const childA = makeService('A', 'degraded');
+      const childB = makeService('B', 'degraded');
+      const childC = makeService('C', 'operational');
+
+      const composite = createCompositeService('Composite', [childA, childB, childC], 'majority');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('degraded');
+    });
+
+    it('should fall back to worst-case when no status has >50%', () => {
+      // 3 children, each with a different status — no majority
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'degraded');
+      const childC = makeService('C', 'major_outage');
+
+      const composite = createCompositeService('Composite', [childA, childB, childC], 'majority');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // No majority => worst-case => major_outage
+      expect(result.data).toBe('major_outage');
+    });
+
+    it('should handle two children with split statuses (50/50 is not >50%)', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'degraded');
+
+      const composite = createCompositeService('Composite', [childA, childB], 'majority');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // 50% is not > 50%, so falls back to worst-case => degraded
+      expect(result.data).toBe('degraded');
+    });
+
+    it('should handle single child as automatic majority', () => {
+      const child = makeService('Only Child', 'major_outage');
+
+      const composite = createCompositeService('Composite', [child], 'majority');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('major_outage');
+    });
+
+    it('should detect majority with 4 children (3 same)', () => {
+      const childA = makeService('A', 'degraded');
+      const childB = makeService('B', 'degraded');
+      const childC = makeService('C', 'degraded');
+      const childD = makeService('D', 'operational');
+
+      const composite = createCompositeService('Composite', [childA, childB, childC, childD], 'majority');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('degraded');
+    });
+  });
+
+  // ── computeStatus: weighted ──
+
+  describe('computeStatus — weighted', () => {
+    it('should derive status from highest total weight', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'degraded');
+
+      const composite = createCompositeService('Composite', [], 'weighted');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      // Add children with different weights
+      addChild(composite.data.id, childA, 5.0);
+      addChild(composite.data.id, childB, 1.0);
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // operational has weight 5, degraded has weight 1 => operational wins
+      expect(result.data).toBe('operational');
+    });
+
+    it('should pick degraded when it has higher total weight', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'degraded');
+      const childC = makeService('C', 'degraded');
+
+      const composite = createCompositeService('Composite', [], 'weighted');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      addChild(composite.data.id, childA, 1.0);
+      addChild(composite.data.id, childB, 3.0);
+      addChild(composite.data.id, childC, 3.0);
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // degraded total weight = 6, operational total weight = 1 => degraded
+      expect(result.data).toBe('degraded');
+    });
+
+    it('should break ties by worst severity', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'degraded');
+
+      const composite = createCompositeService('Composite', [], 'weighted');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      // Equal weights
+      addChild(composite.data.id, childA, 2.0);
+      addChild(composite.data.id, childB, 2.0);
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Equal weight => tie broken by severity => degraded is worse => degraded wins
+      expect(result.data).toBe('degraded');
+    });
+
+    it('should handle multiple statuses with accumulated weights', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'operational');
+      const childC = makeService('C', 'major_outage');
+
+      const composite = createCompositeService('Composite', [], 'weighted');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      addChild(composite.data.id, childA, 2.0);
+      addChild(composite.data.id, childB, 2.0);
+      addChild(composite.data.id, childC, 3.0);
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // operational total = 4, major_outage total = 3 => operational wins
+      expect(result.data).toBe('operational');
+    });
+
+    it('should work with fractional weights', () => {
+      const childA = makeService('A', 'degraded');
+      const childB = makeService('B', 'operational');
+
+      const composite = createCompositeService('Composite', [], 'weighted');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      addChild(composite.data.id, childA, 0.5);
+      addChild(composite.data.id, childB, 0.3);
+
+      const result = computeStatus(composite.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // degraded = 0.5, operational = 0.3 => degraded wins
+      expect(result.data).toBe('degraded');
+    });
+  });
+
+  // ── Status recomputation after child status changes ──
+
+  describe('status recomputation', () => {
+    it('should reflect changes in child status on recomputation', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'operational');
+
+      const composite = createCompositeService('Composite', [childA, childB], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      // Initially all operational
+      let result = computeStatus(composite.data.id);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('operational');
+
+      // Child B goes down
+      updateServiceStatus(childB, 'major_outage');
+
+      // Recompute
+      result = computeStatus(composite.data.id);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('major_outage');
+
+      // Child B recovers
+      updateServiceStatus(childB, 'operational');
+
+      result = computeStatus(composite.data.id);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('operational');
+    });
+
+    it('should update status after adding a degraded child', () => {
+      const childA = makeService('A', 'operational');
+
+      const composite = createCompositeService('Composite', [childA], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      let result = computeStatus(composite.data.id);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('operational');
+
+      // Add a degraded child
+      const childB = makeService('B', 'degraded');
+      addChild(composite.data.id, childB);
+
+      result = computeStatus(composite.data.id);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('degraded');
+    });
+
+    it('should update status after removing a failing child', () => {
+      const childA = makeService('A', 'operational');
+      const childB = makeService('B', 'major_outage');
+
+      const composite = createCompositeService('Composite', [childA, childB], 'worst-case');
+      expect(composite.ok).toBe(true);
+      if (!composite.ok) return;
+
+      let result = computeStatus(composite.data.id);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('major_outage');
+
+      // Remove the failing child
+      removeChild(composite.data.id, childB);
+
+      result = computeStatus(composite.data.id);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBe('operational');
+    });
+  });
+});

--- a/tests/maintenance-notification.test.ts
+++ b/tests/maintenance-notification.test.ts
@@ -1,0 +1,738 @@
+/**
+ * Maintenance Notification Tests
+ *
+ * Tests for the maintenance notification scheduler: pre-notification
+ * timing, start/end triggers, duplicate prevention, webhook dispatch,
+ * SSE broadcasting, and notification tracking persistence.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest';
+import { getDb, closeDb } from '../src/storage/database.js';
+import { createService } from '../src/storage/index.js';
+import { createMaintenanceWindow } from '../src/maintenance/maintenance-repo.js';
+import { createWebhook } from '../src/notifications/webhook-repo.js';
+import {
+  checkMaintenanceWindows,
+  startMaintenanceNotifier,
+  stopMaintenanceNotifier,
+  hasNotificationBeenSent,
+  recordNotificationSent,
+  getNotificationsForWindow,
+} from '../src/maintenance/notification-scheduler.js';
+
+// Mock fetch for webhook delivery
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock the event bus
+const mockBroadcast = vi.fn();
+vi.mock('../src/api/event-stream.js', () => ({
+  getEventBus: () => ({
+    broadcast: mockBroadcast,
+  }),
+}));
+
+// Mock nodemailer to avoid real SMTP connections
+vi.mock('nodemailer', () => ({
+  default: {
+    createTransport: () => ({
+      sendMail: vi.fn().mockResolvedValue({ messageId: 'test-msg-id' }),
+    }),
+  },
+}));
+
+describe('Maintenance Notification Scheduler', () => {
+  let db: ReturnType<typeof getDb>;
+  let serviceId: string;
+
+  beforeAll(() => {
+    process.env.DB_PATH = ':memory:';
+    process.env.LOG_LEVEL = 'error';
+    db = getDb();
+  });
+
+  afterAll(() => {
+    stopMaintenanceNotifier();
+    closeDb();
+  });
+
+  beforeEach(() => {
+    // Clear tables in FK-safe order
+    db.exec('DELETE FROM maintenance_notifications');
+    db.exec('DELETE FROM maintenance_windows');
+    db.exec('DELETE FROM webhook_dead_letters');
+    db.exec('DELETE FROM webhook_deliveries');
+    db.exec('DELETE FROM webhooks');
+    db.exec('DELETE FROM subscriptions');
+    db.exec('DELETE FROM incident_updates');
+    db.exec('DELETE FROM incident_services');
+    db.exec('DELETE FROM incidents');
+    db.exec('DELETE FROM check_results');
+    db.exec('DELETE FROM services');
+
+    // Reset mocks
+    mockFetch.mockReset();
+    mockBroadcast.mockReset();
+
+    // Default fetch to return OK
+    mockFetch.mockResolvedValue(new Response('OK', { status: 200 }));
+
+    // Create a test service
+    const result = createService({
+      name: 'Notification Test Service',
+      url: 'https://api.example.com/health',
+    });
+    expect(result.ok).toBe(true);
+    serviceId = result.data.id;
+  });
+
+  // ── Notification State Tracking ─────────────────────────────────────
+
+  describe('notification state tracking', () => {
+    it('should record a notification as sent', () => {
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Test Window',
+        startAt: '2026-06-01T02:00:00.000Z',
+        endAt: '2026-06-01T04:00:00.000Z',
+      });
+      expect(windowResult.ok).toBe(true);
+      const windowId = windowResult.data.id;
+
+      const result = recordNotificationSent(windowId, 'upcoming');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.maintenanceWindowId).toBe(windowId);
+        expect(result.data.notificationType).toBe('upcoming');
+        expect(result.data.sentAt).toBeDefined();
+        expect(result.data.id).toBeDefined();
+      }
+    });
+
+    it('should detect when a notification has been sent', () => {
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Test Window',
+        startAt: '2026-06-01T02:00:00.000Z',
+        endAt: '2026-06-01T04:00:00.000Z',
+      });
+      expect(windowResult.ok).toBe(true);
+      const windowId = windowResult.data.id;
+
+      expect(hasNotificationBeenSent(windowId, 'upcoming')).toBe(false);
+
+      recordNotificationSent(windowId, 'upcoming');
+
+      expect(hasNotificationBeenSent(windowId, 'upcoming')).toBe(true);
+    });
+
+    it('should track different notification types independently', () => {
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Test Window',
+        startAt: '2026-06-01T02:00:00.000Z',
+        endAt: '2026-06-01T04:00:00.000Z',
+      });
+      expect(windowResult.ok).toBe(true);
+      const windowId = windowResult.data.id;
+
+      recordNotificationSent(windowId, 'upcoming');
+
+      expect(hasNotificationBeenSent(windowId, 'upcoming')).toBe(true);
+      expect(hasNotificationBeenSent(windowId, 'started')).toBe(false);
+      expect(hasNotificationBeenSent(windowId, 'ended')).toBe(false);
+    });
+
+    it('should prevent duplicate notification recording', () => {
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Test Window',
+        startAt: '2026-06-01T02:00:00.000Z',
+        endAt: '2026-06-01T04:00:00.000Z',
+      });
+      expect(windowResult.ok).toBe(true);
+      const windowId = windowResult.data.id;
+
+      const first = recordNotificationSent(windowId, 'started');
+      expect(first.ok).toBe(true);
+
+      const second = recordNotificationSent(windowId, 'started');
+      expect(second.ok).toBe(false);
+      if (!second.ok) {
+        expect(second.error.code).toBe('DUPLICATE');
+      }
+    });
+
+    it('should retrieve all notifications for a window', () => {
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Test Window',
+        startAt: '2026-06-01T02:00:00.000Z',
+        endAt: '2026-06-01T04:00:00.000Z',
+      });
+      expect(windowResult.ok).toBe(true);
+      const windowId = windowResult.data.id;
+
+      recordNotificationSent(windowId, 'upcoming');
+      recordNotificationSent(windowId, 'started');
+      recordNotificationSent(windowId, 'ended');
+
+      const result = getNotificationsForWindow(windowId);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.length).toBe(3);
+        const types = result.data.map((n) => n.notificationType);
+        expect(types).toContain('upcoming');
+        expect(types).toContain('started');
+        expect(types).toContain('ended');
+      }
+    });
+
+    it('should return empty array for window with no notifications', () => {
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Silent Window',
+        startAt: '2026-06-01T02:00:00.000Z',
+        endAt: '2026-06-01T04:00:00.000Z',
+      });
+      expect(windowResult.ok).toBe(true);
+
+      const result = getNotificationsForWindow(windowResult.data.id);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.length).toBe(0);
+      }
+    });
+  });
+
+  // ── Pre-notification Timing ─────────────────────────────────────────
+
+  describe('pre-notification timing (upcoming)', () => {
+    it('should send upcoming notification when window starts within 1 hour', async () => {
+      const now = Date.now();
+      const thirtyMinutes = 30 * 60 * 1000;
+      const twoHours = 2 * 60 * 60 * 1000;
+
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Starting soon',
+        startAt: new Date(now + thirtyMinutes).toISOString(),
+        endAt: new Date(now + twoHours).toISOString(),
+      });
+      expect(windowResult.ok).toBe(true);
+
+      await checkMaintenanceWindows();
+
+      // Should have broadcast an 'upcoming' SSE event
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'maintenance.upcoming',
+        expect.objectContaining({
+          maintenanceWindowId: windowResult.data.id,
+          notificationType: 'upcoming',
+        }),
+      );
+
+      // Should have recorded the notification
+      expect(hasNotificationBeenSent(windowResult.data.id, 'upcoming')).toBe(true);
+    });
+
+    it('should NOT send upcoming notification for windows more than 1 hour away', async () => {
+      const now = Date.now();
+      const twoHours = 2 * 60 * 60 * 1000;
+      const fourHours = 4 * 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'Far future',
+        startAt: new Date(now + twoHours).toISOString(),
+        endAt: new Date(now + fourHours).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      // No upcoming broadcast
+      const upcomingCalls = mockBroadcast.mock.calls.filter(
+        (c: [string, unknown]) => c[0] === 'maintenance.upcoming',
+      );
+      expect(upcomingCalls.length).toBe(0);
+    });
+
+    it('should NOT send upcoming notification for already-started windows', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'Already active',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      // Should see 'started' but NOT 'upcoming'
+      const upcomingCalls = mockBroadcast.mock.calls.filter(
+        (c: [string, unknown]) => c[0] === 'maintenance.upcoming',
+      );
+      expect(upcomingCalls.length).toBe(0);
+    });
+  });
+
+  // ── Start Notification ──────────────────────────────────────────────
+
+  describe('started notification', () => {
+    it('should send started notification for active maintenance window', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Active maintenance',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+      expect(windowResult.ok).toBe(true);
+
+      await checkMaintenanceWindows();
+
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'maintenance.started',
+        expect.objectContaining({
+          maintenanceWindowId: windowResult.data.id,
+          notificationType: 'started',
+        }),
+      );
+
+      expect(hasNotificationBeenSent(windowResult.data.id, 'started')).toBe(true);
+    });
+  });
+
+  // ── End Notification ────────────────────────────────────────────────
+
+  describe('ended notification', () => {
+    it('should send ended notification for completed maintenance window', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+      const twoHours = 2 * 60 * 60 * 1000;
+
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Completed maintenance',
+        startAt: new Date(now - twoHours).toISOString(),
+        endAt: new Date(now - oneHour).toISOString(),
+      });
+      expect(windowResult.ok).toBe(true);
+
+      await checkMaintenanceWindows();
+
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'maintenance.ended',
+        expect.objectContaining({
+          maintenanceWindowId: windowResult.data.id,
+          notificationType: 'ended',
+        }),
+      );
+
+      expect(hasNotificationBeenSent(windowResult.data.id, 'ended')).toBe(true);
+    });
+  });
+
+  // ── Duplicate Prevention ────────────────────────────────────────────
+
+  describe('duplicate prevention', () => {
+    it('should NOT send the same notification type twice for the same window', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'No duplicates',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+      expect(windowResult.ok).toBe(true);
+
+      // First check — should send 'started'
+      await checkMaintenanceWindows();
+      expect(mockBroadcast).toHaveBeenCalledTimes(1);
+
+      mockBroadcast.mockClear();
+
+      // Second check — should NOT send 'started' again
+      await checkMaintenanceWindows();
+      expect(mockBroadcast).not.toHaveBeenCalledWith(
+        'maintenance.started',
+        expect.anything(),
+      );
+    });
+
+    it('should send different notification types for the same window', async () => {
+      const now = Date.now();
+      const thirtyMin = 30 * 60 * 1000;
+      const twoHours = 2 * 60 * 60 * 1000;
+
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Multi-phase',
+        startAt: new Date(now + thirtyMin).toISOString(),
+        endAt: new Date(now + twoHours).toISOString(),
+      });
+      expect(windowResult.ok).toBe(true);
+
+      // First check — upcoming (within 1 hour)
+      await checkMaintenanceWindows();
+
+      const result = getNotificationsForWindow(windowResult.data.id);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.length).toBe(1);
+        expect(result.data[0].notificationType).toBe('upcoming');
+      }
+    });
+  });
+
+  // ── Webhook Integration ─────────────────────────────────────────────
+
+  describe('webhook dispatch', () => {
+    it('should deliver maintenance notifications to enabled webhooks', async () => {
+      // Create a webhook
+      const webhookResult = createWebhook(
+        'https://hooks.example.com/maintenance',
+        ['service.down'],
+      );
+      expect(webhookResult.ok).toBe(true);
+
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'Webhook test',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      // Verify fetch was called with the webhook URL
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://hooks.example.com/maintenance',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('maintenance.started'),
+        }),
+      );
+    });
+
+    it('should include HMAC signature when webhook has a secret', async () => {
+      const webhookResult = createWebhook(
+        'https://hooks.example.com/signed',
+        ['service.down'],
+        'my-secret-key',
+      );
+      expect(webhookResult.ok).toBe(true);
+
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'Signed webhook test',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      // Verify the fetch call included a signature header
+      const fetchCall = mockFetch.mock.calls.find(
+        (call: [string | URL | Request, RequestInit | undefined]) => {
+          const url = call[0];
+          return typeof url === 'string' && url.includes('signed');
+        },
+      );
+      expect(fetchCall).toBeDefined();
+      if (fetchCall) {
+        const opts = fetchCall[1] as RequestInit;
+        const headers = opts.headers as Record<string, string>;
+        expect(headers['X-StatusOwl-Signature']).toMatch(/^sha256=[a-f0-9]+$/);
+      }
+    });
+
+    it('should not fail when webhook delivery returns an error', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('Server Error', { status: 500 }));
+
+      createWebhook('https://hooks.example.com/failing', ['service.down']);
+
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Error resilience test',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+      expect(windowResult.ok).toBe(true);
+
+      // Should not throw
+      await expect(checkMaintenanceWindows()).resolves.not.toThrow();
+
+      // Notification should still be recorded (delivery failure does not block recording)
+      expect(hasNotificationBeenSent(windowResult.data.id, 'started')).toBe(true);
+    });
+
+    it('should not fail when no webhooks are configured', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'No webhooks',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+
+      // Should complete without errors
+      await expect(checkMaintenanceWindows()).resolves.not.toThrow();
+    });
+  });
+
+  // ── SSE Broadcasting ───────────────────────────────────────────────
+
+  describe('SSE broadcasting', () => {
+    it('should broadcast maintenance.upcoming SSE event', async () => {
+      const now = Date.now();
+      const thirtyMin = 30 * 60 * 1000;
+      const twoHours = 2 * 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'SSE upcoming',
+        startAt: new Date(now + thirtyMin).toISOString(),
+        endAt: new Date(now + twoHours).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'maintenance.upcoming',
+        expect.objectContaining({
+          title: 'SSE upcoming',
+          serviceId,
+          notificationType: 'upcoming',
+        }),
+      );
+    });
+
+    it('should broadcast maintenance.started SSE event', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'SSE started',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'maintenance.started',
+        expect.objectContaining({
+          title: 'SSE started',
+          serviceId,
+          notificationType: 'started',
+        }),
+      );
+    });
+
+    it('should broadcast maintenance.ended SSE event', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+      const twoHours = 2 * 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'SSE ended',
+        startAt: new Date(now - twoHours).toISOString(),
+        endAt: new Date(now - oneHour).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'maintenance.ended',
+        expect.objectContaining({
+          title: 'SSE ended',
+          serviceId,
+          notificationType: 'ended',
+        }),
+      );
+    });
+
+    it('should include all expected fields in SSE payload', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      const windowResult = createMaintenanceWindow({
+        serviceId,
+        title: 'Full payload test',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+      expect(windowResult.ok).toBe(true);
+
+      await checkMaintenanceWindows();
+
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'maintenance.started',
+        expect.objectContaining({
+          maintenanceWindowId: windowResult.data.id,
+          serviceId,
+          title: 'Full payload test',
+          startAt: windowResult.data.startAt,
+          endAt: windowResult.data.endAt,
+          notificationType: 'started',
+          timestamp: expect.any(String),
+        }),
+      );
+    });
+  });
+
+  // ── Scheduler Lifecycle ─────────────────────────────────────────────
+
+  describe('scheduler lifecycle', () => {
+    it('should start and stop without errors', () => {
+      expect(() => startMaintenanceNotifier()).not.toThrow();
+
+      // Starting again should warn but not throw
+      expect(() => startMaintenanceNotifier()).not.toThrow();
+
+      expect(() => stopMaintenanceNotifier()).not.toThrow();
+    });
+
+    it('should stop gracefully when not running', () => {
+      stopMaintenanceNotifier(); // Already stopped
+      expect(() => stopMaintenanceNotifier()).not.toThrow();
+    });
+  });
+
+  // ── Edge Cases ──────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('should handle multiple windows in a single scan', async () => {
+      const now = Date.now();
+      const thirtyMin = 30 * 60 * 1000;
+      const oneHour = 60 * 60 * 1000;
+      const twoHours = 2 * 60 * 60 * 1000;
+
+      // Upcoming window
+      createMaintenanceWindow({
+        serviceId,
+        title: 'Upcoming',
+        startAt: new Date(now + thirtyMin).toISOString(),
+        endAt: new Date(now + twoHours).toISOString(),
+      });
+
+      // Active window
+      createMaintenanceWindow({
+        serviceId,
+        title: 'Active',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+
+      // Ended window
+      createMaintenanceWindow({
+        serviceId,
+        title: 'Ended',
+        startAt: new Date(now - twoHours).toISOString(),
+        endAt: new Date(now - oneHour).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      // Should have broadcast 3 events: upcoming, started, ended
+      expect(mockBroadcast).toHaveBeenCalledTimes(3);
+
+      const eventTypes = mockBroadcast.mock.calls.map(
+        (c: [string, unknown]) => c[0],
+      );
+      expect(eventTypes).toContain('maintenance.upcoming');
+      expect(eventTypes).toContain('maintenance.started');
+      expect(eventTypes).toContain('maintenance.ended');
+    });
+
+    it('should handle no maintenance windows gracefully', async () => {
+      await expect(checkMaintenanceWindows()).resolves.not.toThrow();
+      expect(mockBroadcast).not.toHaveBeenCalled();
+    });
+
+    it('should not send notifications for future windows outside pre-notify range', async () => {
+      const now = Date.now();
+      const threeHours = 3 * 60 * 60 * 1000;
+      const fourHours = 4 * 60 * 60 * 1000;
+
+      createMaintenanceWindow({
+        serviceId,
+        title: 'Far future',
+        startAt: new Date(now + threeHours).toISOString(),
+        endAt: new Date(now + fourHours).toISOString(),
+      });
+
+      await checkMaintenanceWindows();
+
+      expect(mockBroadcast).not.toHaveBeenCalled();
+    });
+
+    it('should handle notification tracking across separate windows', async () => {
+      const now = Date.now();
+      const oneHour = 60 * 60 * 1000;
+
+      // Create second service
+      const svc2Result = createService({
+        name: 'Second Service',
+        url: 'https://other.example.com/health',
+      });
+      expect(svc2Result.ok).toBe(true);
+
+      const win1Result = createMaintenanceWindow({
+        serviceId,
+        title: 'Window for service 1',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+      expect(win1Result.ok).toBe(true);
+
+      const win2Result = createMaintenanceWindow({
+        serviceId: svc2Result.data.id,
+        title: 'Window for service 2',
+        startAt: new Date(now - oneHour).toISOString(),
+        endAt: new Date(now + oneHour).toISOString(),
+      });
+      expect(win2Result.ok).toBe(true);
+
+      await checkMaintenanceWindows();
+
+      // Both should have been notified
+      expect(hasNotificationBeenSent(win1Result.data.id, 'started')).toBe(true);
+      expect(hasNotificationBeenSent(win2Result.data.id, 'started')).toBe(true);
+
+      // They should have separate notification records
+      const notifs1 = getNotificationsForWindow(win1Result.data.id);
+      const notifs2 = getNotificationsForWindow(win2Result.data.id);
+
+      expect(notifs1.ok).toBe(true);
+      expect(notifs2.ok).toBe(true);
+      if (notifs1.ok && notifs2.ok) {
+        expect(notifs1.data.length).toBe(1);
+        expect(notifs2.data.length).toBe(1);
+      }
+    });
+  });
+});

--- a/tests/tag-repo.test.ts
+++ b/tests/tag-repo.test.ts
@@ -1,0 +1,550 @@
+/**
+ * Tag Repository Tests
+ *
+ * Tests for tag CRUD, service-tag associations, and tag-based filtering.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
+import {
+  createTag,
+  getTag,
+  listTags,
+  deleteTag,
+  addTagToService,
+  removeTagFromService,
+  getTagsForService,
+  getServicesByTag,
+} from '../src/storage/tag-repo.js';
+import { createService, deleteService } from '../src/storage/service-repo.js';
+import { getDb, closeDb } from '../src/storage/database.js';
+import type { CreateService } from '../src/core/index.js';
+
+describe('Tag Repository', () => {
+  let db: ReturnType<typeof getDb>;
+
+  /** Helper to create a service and return its ID. */
+  function makeService(name: string): string {
+    const input: CreateService = { name, url: `https://${name.toLowerCase().replace(/\s+/g, '-')}.example.com` };
+    const result = createService(input);
+    if (!result.ok) throw new Error(`Failed to create service: ${result.error.message}`);
+    return result.data.id;
+  }
+
+  /** Helper to create a tag and return its ID. */
+  function makeTag(name: string, color?: string): string {
+    const result = createTag(name, color);
+    if (!result.ok) throw new Error(`Failed to create tag: ${result.error.message}`);
+    return result.data.id;
+  }
+
+  beforeAll(() => {
+    process.env.DB_PATH = ':memory:';
+    process.env.LOG_LEVEL = 'error';
+    db = getDb();
+  });
+
+  afterAll(() => {
+    closeDb();
+  });
+
+  beforeEach(() => {
+    // Clear relevant tables before each test for isolation
+    db.prepare('DELETE FROM service_tags').run();
+    db.prepare('DELETE FROM tags').run();
+    db.prepare('DELETE FROM service_dependencies').run();
+    db.prepare('DELETE FROM incident_updates').run();
+    db.prepare('DELETE FROM incident_services').run();
+    db.prepare('DELETE FROM incidents').run();
+    db.prepare('DELETE FROM check_results').run();
+    db.prepare('DELETE FROM services').run();
+    db.prepare('DELETE FROM service_groups').run();
+  });
+
+  // ── Tag CRUD ──
+
+  describe('createTag', () => {
+    it('should create a tag with a name and explicit color', () => {
+      const result = createTag('production', '#ef4444');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.id).toBeDefined();
+      expect(result.data.name).toBe('production');
+      expect(result.data.color).toBe('#ef4444');
+      expect(result.data.createdAt).toBeDefined();
+    });
+
+    it('should assign a default color when none is provided', () => {
+      const result = createTag('staging');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    });
+
+    it('should rotate through default colors for successive tags', () => {
+      const colors: string[] = [];
+      for (let i = 0; i < 12; i++) {
+        const result = createTag(`tag-${i}`);
+        if (!result.ok) throw new Error('Failed to create tag');
+        colors.push(result.data.color);
+      }
+
+      // The 11th and 12th tags (index 10, 11) should wrap around to the beginning
+      expect(colors[10]).toBe(colors[0]);
+      expect(colors[11]).toBe(colors[1]);
+    });
+
+    it('should trim whitespace from tag names', () => {
+      const result = createTag('  frontend  ');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.name).toBe('frontend');
+    });
+
+    it('should reject duplicate tag names', () => {
+      const first = createTag('critical');
+      expect(first.ok).toBe(true);
+
+      const duplicate = createTag('critical');
+
+      expect(duplicate.ok).toBe(false);
+      if (duplicate.ok) return;
+      expect(duplicate.error.code).toBe('DUPLICATE');
+      expect(duplicate.error.message).toContain('already exists');
+    });
+  });
+
+  describe('getTag', () => {
+    it('should retrieve a tag by ID', () => {
+      const created = createTag('backend', '#10b981');
+      if (!created.ok) throw new Error('Setup failed');
+
+      const result = getTag(created.data.id);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.id).toBe(created.data.id);
+      expect(result.data.name).toBe('backend');
+      expect(result.data.color).toBe('#10b981');
+    });
+
+    it('should return NOT_FOUND for non-existent tag', () => {
+      const result = getTag('00000000-0000-0000-0000-000000000000');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('listTags', () => {
+    it('should return all tags ordered by name', () => {
+      createTag('zulu');
+      createTag('alpha');
+      createTag('mike');
+
+      const result = listTags();
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(3);
+      expect(result.data[0].name).toBe('alpha');
+      expect(result.data[1].name).toBe('mike');
+      expect(result.data[2].name).toBe('zulu');
+    });
+
+    it('should return an empty array when no tags exist', () => {
+      const result = listTags();
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(0);
+    });
+  });
+
+  describe('deleteTag', () => {
+    it('should delete an existing tag', () => {
+      const tagId = makeTag('temporary');
+
+      const result = deleteTag(tagId);
+
+      expect(result.ok).toBe(true);
+
+      // Verify it's gone
+      const getResult = getTag(tagId);
+      expect(getResult.ok).toBe(false);
+    });
+
+    it('should return NOT_FOUND for non-existent tag', () => {
+      const result = deleteTag('00000000-0000-0000-0000-000000000000');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+
+    it('should cascade delete service-tag associations when tag is deleted', () => {
+      const tagId = makeTag('doomed');
+      const serviceId = makeService('Linked Service');
+      addTagToService(serviceId, tagId);
+
+      // Verify the association exists
+      const tagsBefore = getTagsForService(serviceId);
+      expect(tagsBefore.ok).toBe(true);
+      if (!tagsBefore.ok) return;
+      expect(tagsBefore.data.length).toBe(1);
+
+      // Delete the tag
+      deleteTag(tagId);
+
+      // Association should be gone
+      const tagsAfter = getTagsForService(serviceId);
+      expect(tagsAfter.ok).toBe(true);
+      if (!tagsAfter.ok) return;
+      expect(tagsAfter.data.length).toBe(0);
+    });
+  });
+
+  // ── Service-Tag Associations ──
+
+  describe('addTagToService', () => {
+    it('should associate a tag with a service', () => {
+      const serviceId = makeService('My API');
+      const tagId = makeTag('production');
+
+      const result = addTagToService(serviceId, tagId);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.serviceId).toBe(serviceId);
+      expect(result.data.tagId).toBe(tagId);
+    });
+
+    it('should reject duplicate service-tag association', () => {
+      const serviceId = makeService('My API');
+      const tagId = makeTag('production');
+
+      const first = addTagToService(serviceId, tagId);
+      expect(first.ok).toBe(true);
+
+      const duplicate = addTagToService(serviceId, tagId);
+
+      expect(duplicate.ok).toBe(false);
+      if (duplicate.ok) return;
+      expect(duplicate.error.code).toBe('DUPLICATE');
+    });
+
+    it('should reject association with non-existent tag', () => {
+      const serviceId = makeService('My API');
+
+      const result = addTagToService(serviceId, '00000000-0000-0000-0000-000000000000');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+
+    it('should reject association with non-existent service', () => {
+      const tagId = makeTag('orphan');
+
+      const result = addTagToService('00000000-0000-0000-0000-000000000000', tagId);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+
+    it('should allow multiple tags on one service', () => {
+      const serviceId = makeService('Multi-Tag Service');
+      const tag1 = makeTag('production');
+      const tag2 = makeTag('critical');
+      const tag3 = makeTag('backend');
+
+      addTagToService(serviceId, tag1);
+      addTagToService(serviceId, tag2);
+      addTagToService(serviceId, tag3);
+
+      const tags = getTagsForService(serviceId);
+      expect(tags.ok).toBe(true);
+      if (!tags.ok) return;
+      expect(tags.data.length).toBe(3);
+    });
+
+    it('should allow one tag on multiple services', () => {
+      const tagId = makeTag('shared-tag');
+      const service1 = makeService('Service A');
+      const service2 = makeService('Service B');
+      const service3 = makeService('Service C');
+
+      addTagToService(service1, tagId);
+      addTagToService(service2, tagId);
+      addTagToService(service3, tagId);
+
+      const result = getServicesByTag([tagId], 'or');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(3);
+    });
+  });
+
+  describe('removeTagFromService', () => {
+    it('should remove a tag from a service', () => {
+      const serviceId = makeService('My API');
+      const tagId = makeTag('production');
+      addTagToService(serviceId, tagId);
+
+      const result = removeTagFromService(serviceId, tagId);
+
+      expect(result.ok).toBe(true);
+
+      // Verify it's gone
+      const tags = getTagsForService(serviceId);
+      expect(tags.ok).toBe(true);
+      if (!tags.ok) return;
+      expect(tags.data.length).toBe(0);
+    });
+
+    it('should return NOT_FOUND when tag is not assigned to service', () => {
+      const serviceId = makeService('My API');
+      const tagId = makeTag('unlinked');
+
+      const result = removeTagFromService(serviceId, tagId);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('getTagsForService', () => {
+    it('should return all tags for a service ordered by name', () => {
+      const serviceId = makeService('Tagged Service');
+      const tagZ = makeTag('zulu-tag');
+      const tagA = makeTag('alpha-tag');
+      const tagM = makeTag('mike-tag');
+
+      addTagToService(serviceId, tagZ);
+      addTagToService(serviceId, tagA);
+      addTagToService(serviceId, tagM);
+
+      const result = getTagsForService(serviceId);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(3);
+      expect(result.data[0].name).toBe('alpha-tag');
+      expect(result.data[1].name).toBe('mike-tag');
+      expect(result.data[2].name).toBe('zulu-tag');
+    });
+
+    it('should return an empty array for a service with no tags', () => {
+      const serviceId = makeService('No Tags');
+
+      const result = getTagsForService(serviceId);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(0);
+    });
+  });
+
+  // ── Cascade on service deletion ──
+
+  describe('cascade on service deletion', () => {
+    it('should remove service-tag associations when a service is deleted', () => {
+      const serviceId = makeService('Doomed Service');
+      const tagId = makeTag('survivor');
+      addTagToService(serviceId, tagId);
+
+      // Delete the service
+      deleteService(serviceId);
+
+      // The tag should still exist
+      const tag = getTag(tagId);
+      expect(tag.ok).toBe(true);
+
+      // But the association should be gone (no services with this tag)
+      const services = getServicesByTag([tagId], 'or');
+      expect(services.ok).toBe(true);
+      if (!services.ok) return;
+      expect(services.data.length).toBe(0);
+    });
+  });
+
+  // ── Filtering by Tags ──
+
+  describe('getServicesByTag', () => {
+    it('should return an empty array when no tag IDs are provided', () => {
+      const result = getServicesByTag([], 'or');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.length).toBe(0);
+    });
+
+    describe('OR mode', () => {
+      it('should return services matching ANY of the given tags', () => {
+        const tagProd = makeTag('production');
+        const tagStaging = makeTag('staging');
+        const tagDev = makeTag('development');
+
+        const serviceA = makeService('Service A'); // production
+        const serviceB = makeService('Service B'); // staging
+        const serviceC = makeService('Service C'); // development
+        const _serviceD = makeService('Service D'); // no tags
+
+        addTagToService(serviceA, tagProd);
+        addTagToService(serviceB, tagStaging);
+        addTagToService(serviceC, tagDev);
+
+        // Filter by production OR staging
+        const result = getServicesByTag([tagProd, tagStaging], 'or');
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.data.length).toBe(2);
+        expect(result.data).toContain(serviceA);
+        expect(result.data).toContain(serviceB);
+      });
+
+      it('should not return duplicates when a service matches multiple tags', () => {
+        const tag1 = makeTag('tag-one');
+        const tag2 = makeTag('tag-two');
+
+        const serviceId = makeService('Multi-tag Service');
+        addTagToService(serviceId, tag1);
+        addTagToService(serviceId, tag2);
+
+        const result = getServicesByTag([tag1, tag2], 'or');
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.data.length).toBe(1);
+        expect(result.data[0]).toBe(serviceId);
+      });
+
+      it('should return services matching a single tag', () => {
+        const tagId = makeTag('critical');
+        const serviceId = makeService('Critical Service');
+        addTagToService(serviceId, tagId);
+
+        makeService('Untagged Service');
+
+        const result = getServicesByTag([tagId], 'or');
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.data.length).toBe(1);
+        expect(result.data[0]).toBe(serviceId);
+      });
+    });
+
+    describe('AND mode', () => {
+      it('should return only services matching ALL given tags', () => {
+        const tagProd = makeTag('production');
+        const tagCritical = makeTag('critical');
+
+        const serviceA = makeService('Service A'); // production + critical
+        const serviceB = makeService('Service B'); // production only
+        const _serviceC = makeService('Service C'); // no tags
+
+        addTagToService(serviceA, tagProd);
+        addTagToService(serviceA, tagCritical);
+        addTagToService(serviceB, tagProd);
+
+        // Filter by production AND critical
+        const result = getServicesByTag([tagProd, tagCritical], 'and');
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.data.length).toBe(1);
+        expect(result.data[0]).toBe(serviceA);
+      });
+
+      it('should return an empty array when no service matches all tags', () => {
+        const tag1 = makeTag('tag-alpha');
+        const tag2 = makeTag('tag-bravo');
+
+        const serviceA = makeService('Service A');
+        const serviceB = makeService('Service B');
+
+        addTagToService(serviceA, tag1);
+        addTagToService(serviceB, tag2);
+
+        const result = getServicesByTag([tag1, tag2], 'and');
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.data.length).toBe(0);
+      });
+
+      it('should work with a single tag (equivalent to OR)', () => {
+        const tagId = makeTag('solo');
+        const serviceId = makeService('Solo Service');
+        addTagToService(serviceId, tagId);
+
+        const result = getServicesByTag([tagId], 'and');
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.data.length).toBe(1);
+        expect(result.data[0]).toBe(serviceId);
+      });
+
+      it('should handle three-tag AND filter correctly', () => {
+        const tag1 = makeTag('env-prod');
+        const tag2 = makeTag('tier-critical');
+        const tag3 = makeTag('region-us');
+
+        const serviceA = makeService('Service A'); // all three tags
+        const serviceB = makeService('Service B'); // only two tags
+
+        addTagToService(serviceA, tag1);
+        addTagToService(serviceA, tag2);
+        addTagToService(serviceA, tag3);
+        addTagToService(serviceB, tag1);
+        addTagToService(serviceB, tag2);
+
+        const result = getServicesByTag([tag1, tag2, tag3], 'and');
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.data.length).toBe(1);
+        expect(result.data[0]).toBe(serviceA);
+      });
+    });
+  });
+
+  // ── Tag Color Defaults ──
+
+  describe('tag color defaults', () => {
+    it('should use the provided hex color', () => {
+      const result = createTag('custom-color', '#abcdef');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.color).toBe('#abcdef');
+    });
+
+    it('should assign the first default color to the first tag', () => {
+      const result = createTag('first-tag');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // First default color is '#3b82f6' (blue)
+      expect(result.data.color).toBe('#3b82f6');
+    });
+
+    it('should assign different default colors to successive tags', () => {
+      const result1 = createTag('tag-a');
+      const result2 = createTag('tag-b');
+
+      expect(result1.ok).toBe(true);
+      expect(result2.ok).toBe(true);
+      if (!result1.ok || !result2.ok) return;
+      expect(result1.data.color).not.toBe(result2.data.color);
+    });
+  });
+});

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,592 @@
+/**
+ * Theme Tests
+ *
+ * Tests for:
+ * 1. Theme CSS variable coverage (light/dark have matching vars)
+ * 2. Theme toggle logic (localStorage persistence, OS detection)
+ * 3. Theme API endpoint tests (GET /api/theme, PATCH /api/theme)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+
+// ── CSS Variable Coverage Tests ──
+
+describe('Theme CSS Variables', () => {
+  const themeCssPath = path.resolve(__dirname, '../src/status-page/theme.css');
+  const statusCssPath = path.resolve(__dirname, '../src/status-page/status.css');
+  let themeCss: string;
+  let statusCss: string;
+
+  beforeEach(() => {
+    themeCss = fs.readFileSync(themeCssPath, 'utf-8');
+    statusCss = fs.readFileSync(statusCssPath, 'utf-8');
+  });
+
+  /**
+   * Extract all CSS custom property declarations (--name: value) from a block
+   * identified by a selector string. Uses brace counting to handle nested blocks.
+   */
+  function extractVariables(css: string, selectorLiteral: string): Set<string> {
+    const vars = new Set<string>();
+
+    // Find the selector in the raw CSS text
+    let searchFrom = 0;
+    while (true) {
+      const idx = css.indexOf(selectorLiteral, searchFrom);
+      if (idx === -1) break;
+
+      // Find the opening brace after the selector
+      const openBrace = css.indexOf('{', idx);
+      if (openBrace === -1) break;
+
+      // Walk forward counting braces to find the matching close
+      let depth = 1;
+      let pos = openBrace + 1;
+      while (pos < css.length && depth > 0) {
+        if (css[pos] === '{') depth++;
+        else if (css[pos] === '}') depth--;
+        pos++;
+      }
+
+      const block = css.slice(openBrace + 1, pos - 1);
+
+      // Extract custom property declarations
+      const varRegex = /(--[\w-]+)\s*:/g;
+      let varMatch: RegExpExecArray | null;
+      while ((varMatch = varRegex.exec(block)) !== null) {
+        vars.add(varMatch[1]);
+      }
+
+      searchFrom = pos;
+    }
+
+    return vars;
+  }
+
+  it('should define :root (light) variables in theme.css', () => {
+    const lightVars = extractVariables(themeCss, ':root');
+    expect(lightVars.size).toBeGreaterThan(0);
+    // Core variables must exist
+    expect(lightVars.has('--color-background')).toBe(true);
+    expect(lightVars.has('--color-surface')).toBe(true);
+    expect(lightVars.has('--color-text-primary')).toBe(true);
+    expect(lightVars.has('--color-text-secondary')).toBe(true);
+    expect(lightVars.has('--color-border')).toBe(true);
+    expect(lightVars.has('--color-shadow')).toBe(true);
+  });
+
+  it('should define [data-theme="dark"] variables in theme.css', () => {
+    const darkVars = extractVariables(themeCss, '[data-theme="dark"]');
+    expect(darkVars.size).toBeGreaterThan(0);
+    expect(darkVars.has('--color-background')).toBe(true);
+    expect(darkVars.has('--color-surface')).toBe(true);
+    expect(darkVars.has('--color-text-primary')).toBe(true);
+    expect(darkVars.has('--color-text-secondary')).toBe(true);
+    expect(darkVars.has('--color-border')).toBe(true);
+    expect(darkVars.has('--color-shadow')).toBe(true);
+  });
+
+  it('should have matching color variables between light and dark themes', () => {
+    const lightVars = extractVariables(themeCss, ':root');
+    const darkVars = extractVariables(themeCss, '[data-theme="dark"]');
+
+    // Every color variable in light should have a dark counterpart
+    const lightColorVars = [...lightVars].filter((v) => v.startsWith('--color-'));
+    const darkColorVars = [...darkVars].filter((v) => v.startsWith('--color-'));
+
+    for (const v of lightColorVars) {
+      expect(darkColorVars).toContain(v);
+    }
+  });
+
+  it('should define status colors in both themes', () => {
+    const lightVars = extractVariables(themeCss, ':root');
+    const darkVars = extractVariables(themeCss, '[data-theme="dark"]');
+
+    const statusVars = [
+      '--color-operational',
+      '--color-degraded',
+      '--color-partial-outage',
+      '--color-outage',
+      '--color-maintenance',
+    ];
+
+    for (const v of statusVars) {
+      expect(lightVars.has(v)).toBe(true);
+      expect(darkVars.has(v)).toBe(true);
+    }
+  });
+
+  it('should define severity badge colors in both themes', () => {
+    const lightVars = extractVariables(themeCss, ':root');
+    const darkVars = extractVariables(themeCss, '[data-theme="dark"]');
+
+    const severityVars = [
+      '--color-severity-minor-bg',
+      '--color-severity-minor-text',
+      '--color-severity-major-bg',
+      '--color-severity-major-text',
+      '--color-severity-critical-bg',
+      '--color-severity-critical-text',
+    ];
+
+    for (const v of severityVars) {
+      expect(lightVars.has(v)).toBe(true);
+      expect(darkVars.has(v)).toBe(true);
+    }
+  });
+
+  it('should define calendar heat-map colors in both themes', () => {
+    const lightVars = extractVariables(themeCss, ':root');
+    const darkVars = extractVariables(themeCss, '[data-theme="dark"]');
+
+    for (let level = 0; level <= 4; level++) {
+      const varName = `--color-calendar-level-${level}`;
+      expect(lightVars.has(varName)).toBe(true);
+      expect(darkVars.has(varName)).toBe(true);
+    }
+  });
+
+  it('should define SSE indicator colors in both themes', () => {
+    const lightVars = extractVariables(themeCss, ':root');
+    const darkVars = extractVariables(themeCss, '[data-theme="dark"]');
+
+    expect(lightVars.has('--color-sse-connected')).toBe(true);
+    expect(lightVars.has('--color-sse-disconnected')).toBe(true);
+    expect(darkVars.has('--color-sse-connected')).toBe(true);
+    expect(darkVars.has('--color-sse-disconnected')).toBe(true);
+  });
+
+  it('should define maintenance banner colors in both themes', () => {
+    const lightVars = extractVariables(themeCss, ':root');
+    const darkVars = extractVariables(themeCss, '[data-theme="dark"]');
+
+    const bannerVars = [
+      '--color-maintenance-banner-bg',
+      '--color-maintenance-banner-border',
+      '--color-maintenance-banner-text',
+      '--color-maintenance-banner-icon',
+    ];
+
+    for (const v of bannerVars) {
+      expect(lightVars.has(v)).toBe(true);
+      expect(darkVars.has(v)).toBe(true);
+    }
+  });
+
+  it('should define resolved badge colors in both themes', () => {
+    const lightVars = extractVariables(themeCss, ':root');
+    const darkVars = extractVariables(themeCss, '[data-theme="dark"]');
+
+    expect(lightVars.has('--color-resolved-badge-bg')).toBe(true);
+    expect(lightVars.has('--color-resolved-badge-text')).toBe(true);
+    expect(darkVars.has('--color-resolved-badge-bg')).toBe(true);
+    expect(darkVars.has('--color-resolved-badge-text')).toBe(true);
+  });
+
+  it('should NOT have hardcoded hex colors in status.css', () => {
+    // Strip CSS comments first
+    const noComments = statusCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    // Find any remaining #hex values that are NOT inside var() fallbacks
+    // We allow fallback values like var(--foo, #abc) — those are fine
+    const lines = noComments.split('\n');
+    const hardcodedLines: string[] = [];
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      // Skip empty lines and lines that are just closing braces
+      if (!trimmed || trimmed === '}' || trimmed === '{') continue;
+      // Skip lines that are CSS custom property declarations (--name: #hex)
+      if (/^\s*--[\w-]+\s*:/.test(trimmed)) continue;
+      // Check for hardcoded hex colors
+      if (/#[0-9a-fA-F]{3,8}\b/.test(trimmed)) {
+        hardcodedLines.push(trimmed);
+      }
+    }
+
+    expect(hardcodedLines).toEqual([]);
+  });
+
+  it('should include smooth theme transition rules', () => {
+    expect(themeCss).toContain('transition: background-color 0.3s');
+    expect(themeCss).toContain('color 0.3s');
+    expect(themeCss).toContain('border-color 0.3s');
+  });
+
+  it('should respect prefers-reduced-motion', () => {
+    expect(themeCss).toContain('prefers-reduced-motion: reduce');
+    expect(themeCss).toContain('transition: none');
+  });
+});
+
+// ── Theme Toggle Logic Tests ──
+
+describe('Theme Toggle Logic (status.js)', () => {
+  const statusJsPath = path.resolve(__dirname, '../src/status-page/status.js');
+  let statusJs: string;
+
+  beforeEach(() => {
+    statusJs = fs.readFileSync(statusJsPath, 'utf-8');
+  });
+
+  it('should define THEME_KEY for localStorage persistence', () => {
+    expect(statusJs).toContain("THEME_KEY = 'statusowl-theme'");
+  });
+
+  it('should have getThemePreference function that checks localStorage', () => {
+    expect(statusJs).toContain('function getThemePreference()');
+    expect(statusJs).toContain('localStorage.getItem(THEME_KEY)');
+  });
+
+  it('should detect OS dark mode preference via matchMedia', () => {
+    expect(statusJs).toContain("matchMedia('(prefers-color-scheme: dark)')");
+  });
+
+  it('should have applyTheme function that sets data-theme attribute', () => {
+    expect(statusJs).toContain('function applyTheme(theme)');
+    expect(statusJs).toContain("setAttribute('data-theme'");
+  });
+
+  it('should persist theme choice to localStorage', () => {
+    expect(statusJs).toContain('localStorage.setItem(THEME_KEY, theme)');
+  });
+
+  it('should have toggleTheme function', () => {
+    expect(statusJs).toContain('function toggleTheme()');
+  });
+
+  it('should listen for OS theme changes', () => {
+    expect(statusJs).toContain("addEventListener('change'");
+    // Verify it passes through to the handler
+    expect(statusJs).toContain('mediaQueryListener');
+  });
+
+  it('should update aria-pressed on theme toggle for accessibility', () => {
+    expect(statusJs).toContain("setAttribute('aria-pressed'");
+  });
+
+  it('should read calendar colors from CSS custom properties', () => {
+    expect(statusJs).toContain('getCalendarColors()');
+    expect(statusJs).toContain("getPropertyValue('--color-calendar-level-");
+  });
+
+  it('should initialize theme on page load', () => {
+    expect(statusJs).toContain('initTheme()');
+  });
+});
+
+// ── Theme API Tests ──
+
+// Mock all dependencies that routes.ts and theme-config.ts import
+vi.mock('../src/storage/index.js', () => ({
+  createService: vi.fn(),
+  getService: vi.fn(),
+  listServices: vi.fn(),
+  listServicesPaginated: vi.fn(),
+  updateService: vi.fn(),
+  deleteService: vi.fn(),
+  getRecentChecks: vi.fn(),
+  getUptimeSummary: vi.fn(),
+  getDailyHistory: vi.fn(),
+  getLatestSslCheck: vi.fn(),
+  getSslHistory: vi.fn(),
+  createGroup: vi.fn(),
+  getGroup: vi.fn(),
+  listGroups: vi.fn(),
+  updateGroup: vi.fn(),
+  deleteGroup: vi.fn(),
+  addDependency: vi.fn(),
+  removeDependency: vi.fn(),
+  getDependenciesOf: vi.fn(),
+  getDependentsOn: vi.fn(),
+  getDownstreamServices: vi.fn(),
+}));
+
+vi.mock('../src/monitors/index.js', () => ({
+  scheduleService: vi.fn(),
+  unscheduleService: vi.fn(),
+}));
+
+vi.mock('../src/monitors/percentile-aggregator.js', () => ({
+  getPercentiles: vi.fn(),
+}));
+
+vi.mock('../src/incidents/index.js', () => ({
+  getOpenIncidents: vi.fn(),
+  getIncidentById: vi.fn(),
+  getIncidentsByService: vi.fn(),
+  updateIncidentStatus: vi.fn(),
+}));
+
+vi.mock('../src/maintenance/index.js', () => ({
+  createMaintenanceWindow: vi.fn(),
+  getMaintenanceWindow: vi.fn(),
+  listMaintenanceWindows: vi.fn(),
+  deleteMaintenanceWindow: vi.fn(),
+}));
+
+vi.mock('../src/alerts/index.js', () => ({
+  createAlertPolicy: vi.fn(),
+  getAlertPolicy: vi.fn(),
+  getAlertPolicyByService: vi.fn(),
+  listAlertPolicies: vi.fn(),
+  updateAlertPolicy: vi.fn(),
+  deleteAlertPolicy: vi.fn(),
+}));
+
+vi.mock('../src/auth/index.js', () => ({
+  registerClient: vi.fn(),
+  requestGrant: vi.fn(),
+  introspectToken: vi.fn(),
+  revokeToken: vi.fn(),
+  rotateToken: vi.fn(),
+}));
+
+vi.mock('../src/audit/index.js', () => ({
+  recordAudit: vi.fn(() => ({ ok: true, data: {} })),
+  queryAuditLog: vi.fn(),
+}));
+
+vi.mock('../src/subscriptions/index.js', () => ({
+  createSubscription: vi.fn(),
+  confirmSubscription: vi.fn(),
+  unsubscribe: vi.fn(),
+  listSubscriptions: vi.fn(),
+  deleteSubscription: vi.fn(),
+}));
+
+// Mock database — use a real in-memory map for config table
+const configStore = new Map<string, string>();
+
+vi.mock('../src/storage/database.js', () => ({
+  getDb: vi.fn(() => ({
+    prepare: vi.fn((sql: string) => {
+      if (sql.includes('CREATE TABLE IF NOT EXISTS config')) {
+        return { run: vi.fn() };
+      }
+      if (sql.includes('SELECT value FROM config WHERE key = ?')) {
+        return {
+          get: vi.fn((key: string) => {
+            const val = configStore.get(key);
+            return val ? { value: val } : undefined;
+          }),
+        };
+      }
+      if (sql.includes('INSERT INTO config')) {
+        return {
+          run: vi.fn((_key: string, value: string) => {
+            // Extract key from the INSERT — it is the first param
+            configStore.set(_key, value);
+          }),
+        };
+      }
+      // Default fallback for other queries (from routes.ts mocks)
+      return {
+        all: vi.fn(() => []),
+        get: vi.fn(() => ({ count: 0 })),
+        run: vi.fn(),
+      };
+    }),
+  })),
+  closeDb: vi.fn(),
+}));
+
+vi.mock('../src/api/auth.js', () => ({
+  requireAuth: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+import { themeRouter } from '../src/api/theme-config.js';
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(themeRouter);
+  return app;
+}
+
+describe('Theme API', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    configStore.clear();
+    app = buildApp();
+  });
+
+  describe('GET /api/theme', () => {
+    it('should return 200 with default theme config', async () => {
+      const res = await request(app).get('/api/theme');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('should return system as the default theme', async () => {
+      const res = await request(app).get('/api/theme');
+      expect(res.body.data.defaultTheme).toBe('system');
+    });
+
+    it('should return allowUserToggle as true by default', async () => {
+      const res = await request(app).get('/api/theme');
+      expect(res.body.data.allowUserToggle).toBe(true);
+    });
+
+    it('should return all expected fields', async () => {
+      const res = await request(app).get('/api/theme');
+      const data = res.body.data;
+
+      expect(data).toHaveProperty('defaultTheme');
+      expect(data).toHaveProperty('allowUserToggle');
+    });
+  });
+
+  describe('PATCH /api/theme', () => {
+    it('should update the default theme to dark', async () => {
+      const res = await request(app)
+        .patch('/api/theme')
+        .send({ defaultTheme: 'dark' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data.defaultTheme).toBe('dark');
+    });
+
+    it('should update the default theme to light', async () => {
+      const res = await request(app)
+        .patch('/api/theme')
+        .send({ defaultTheme: 'light' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.defaultTheme).toBe('light');
+    });
+
+    it('should update allowUserToggle', async () => {
+      const res = await request(app)
+        .patch('/api/theme')
+        .send({ allowUserToggle: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.allowUserToggle).toBe(false);
+    });
+
+    it('should reject invalid theme values', async () => {
+      const res = await request(app)
+        .patch('/api/theme')
+        .send({ defaultTheme: 'neon' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error.code).toBe('VALIDATION');
+    });
+
+    it('should reject invalid allowUserToggle values', async () => {
+      const res = await request(app)
+        .patch('/api/theme')
+        .send({ allowUserToggle: 'yes' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.ok).toBe(false);
+    });
+
+    it('should accept partial updates', async () => {
+      // First set dark theme
+      await request(app)
+        .patch('/api/theme')
+        .send({ defaultTheme: 'dark' });
+
+      // Then only update toggle, theme should persist
+      const res = await request(app)
+        .patch('/api/theme')
+        .send({ allowUserToggle: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.defaultTheme).toBe('dark');
+      expect(res.body.data.allowUserToggle).toBe(false);
+    });
+
+    it('should accept custom color overrides', async () => {
+      const res = await request(app)
+        .patch('/api/theme')
+        .send({
+          customLightColors: {
+            '--color-background': '#ffffff',
+            '--color-surface': '#f0f0f0',
+          },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.customLightColors).toBeDefined();
+      expect(res.body.data.customLightColors['--color-background']).toBe('#ffffff');
+    });
+
+    it('should accept empty body without error', async () => {
+      const res = await request(app)
+        .patch('/api/theme')
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+
+  describe('Persistence', () => {
+    it('should persist config changes across reads', async () => {
+      // Update
+      await request(app)
+        .patch('/api/theme')
+        .send({ defaultTheme: 'dark', allowUserToggle: false });
+
+      // Read back
+      const res = await request(app).get('/api/theme');
+      expect(res.body.data.defaultTheme).toBe('dark');
+      expect(res.body.data.allowUserToggle).toBe(false);
+    });
+  });
+});
+
+// ── index.html Tests ──
+
+describe('index.html Theme Integration', () => {
+  const indexHtmlPath = path.resolve(__dirname, '../src/status-page/index.html');
+  let indexHtml: string;
+
+  beforeEach(() => {
+    indexHtml = fs.readFileSync(indexHtmlPath, 'utf-8');
+  });
+
+  it('should include theme.css stylesheet', () => {
+    expect(indexHtml).toContain('href="theme.css"');
+  });
+
+  it('should include theme.css BEFORE status.css', () => {
+    const themeIndex = indexHtml.indexOf('theme.css');
+    const statusIndex = indexHtml.indexOf('status.css');
+    expect(themeIndex).toBeLessThan(statusIndex);
+  });
+
+  it('should have a theme toggle button', () => {
+    expect(indexHtml).toContain('id="theme-toggle"');
+  });
+
+  it('should have aria-label on theme toggle', () => {
+    expect(indexHtml).toContain('aria-label="Toggle dark mode"');
+  });
+
+  it('should have aria-pressed on theme toggle', () => {
+    expect(indexHtml).toContain('aria-pressed=');
+  });
+
+  it('should have sun and moon SVG icons', () => {
+    expect(indexHtml).toContain('class="sun-icon"');
+    expect(indexHtml).toContain('class="moon-icon"');
+  });
+
+  it('should have theme-color meta tags for light and dark', () => {
+    expect(indexHtml).toContain('name="theme-color"');
+    expect(indexHtml).toContain('prefers-color-scheme: light');
+    expect(indexHtml).toContain('prefers-color-scheme: dark');
+  });
+});


### PR DESCRIPTION
## Summary

Six production features implemented via parallel agent fleet, adding 6,808 lines across 23 files:

- **HTTP Response Caching** — ETag/Last-Modified middleware with in-memory LRU cache (500 entries), conditional 304 responses, auto-invalidation on mutations, cache stats (#74)
- **Maintenance Notification Automation** — Pre-maintenance alerts (1h before), start/end notifications via email/webhook/SSE, duplicate prevention with tracking table (#75)
- **Dark Mode + Theme Engine** — CSS custom properties for all colors, light/dark themes, OS preference detection, localStorage persistence, toggle button, server-side config API (#76)
- **Service Tags** — Tag CRUD with colors, service-tag AND/OR filtering, cascade delete, 10 predefined default colors (#77)
- **Composite Services** — Virtual services with aggregated status: worst-case, majority, weighted derivation rules, BFS cycle detection, nested composites (#78)
- **Bulk Operations API** — Batch create/update/delete (up to 100), atomic transaction mode with rollback, partial mode with per-item results, audit logging (#79)

### New Files (7 source + 6 test)
- `src/api/cache-middleware.ts` (572 lines), `src/api/bulk-operations.ts` (333 lines), `src/api/theme-config.ts` (164 lines)
- `src/maintenance/notification-scheduler.ts` (521 lines)
- `src/monitors/composite-service.ts` (450 lines)
- `src/storage/tag-repo.ts` (222 lines)
- `src/status-page/theme.css` (206 lines)

### Modified Files (10)
- `src/storage/database.ts` — Migrations #14-#16
- `src/core/contracts.ts` — Tag/ServiceTag schemas, composite check_type
- `src/status-page/` — All hardcoded colors → CSS variables, theme support
- `src/server.ts` — Theme router registration

## Test plan
- [x] 834 tests across 40 modules — all passing
- [x] 228 new tests (40 cache, 27 maintenance, 42 theme, 34 tags, 46 composite, 39 bulk)
- [x] `npx tsc --noEmit` — zero type errors
- [x] All existing 606 tests from v0.6.0 still passing

Closes #74, #75, #76, #77, #78, #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)