### PR TITLE
fix(api): wire all v0.7.0 routes and middleware into running server

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -5,11 +5,15 @@
  */
 
 import { Router, Request, Response, NextFunction } from 'express';
-import { CreateServiceSchema, CreateServiceGroupSchema, CreateMaintenanceWindowSchema, CreateAlertPolicySchema, CreateSlaTargetSchema, getConfig } from '../core/index.js';
+import { CreateServiceSchema, CreateServiceGroupSchema, CreateMaintenanceWindowSchema, CreateAlertPolicySchema, CreateSlaTargetSchema, WebhookSchema, getConfig } from '../core/index.js';
 import { ok, err } from '../core/index.js';
 import type { ServiceStatus } from '../core/index.js';
 import { createService, getService, listServices, listServicesPaginated, updateService, deleteService } from '../storage/index.js';
 import { generateBadgeSvg, getStatusText } from './badges.js';
+import { createTag, getTag, listTags, deleteTag, addTagToService, removeTagFromService, getTagsForService, getServicesByTag } from '../storage/tag-repo.js';
+import { createCompositeService, addChild, removeChild, getChildren, computeStatus } from '../monitors/composite-service.js';
+import { createWebhook, listWebhooks, getWebhookById, deleteWebhook } from '../notifications/webhook-repo.js';
+import { cacheMiddleware, getCacheStats, invalidateCache } from './cache-middleware.js';
 import { generateWidgetHtml } from './embed-widget.js';
 import { getRecentChecks, getUptimeSummary, getDailyHistory, getLatestSslCheck, getSslHistory } from '../storage/index.js';
 import { getPercentiles } from '../monitors/percentile-aggregator.js';
@@ -45,7 +49,6 @@ import { createSubscription, confirmSubscription, unsubscribe, listSubscriptions
 import { generateReport, getReport, listReports } from '../reports/index.js';
 import { createRegion, listRegions, getRegion, deleteRegion, getRegionalLatency } from '../monitors/region-repo.js';
 import { getDeliveryHistory, retryDelivery } from '../notifications/webhook-delivery.js';
-import { getWebhookById } from '../notifications/webhook-repo.js';
 import { getCalendarData, getOverallCalendarData } from './calendar.js';
 import { getEventBus } from './event-stream.js';
 import {
@@ -1105,4 +1108,184 @@ router.post('/api/webhooks/:id/deliveries/:deliveryId/retry', requireAuth, (req:
     return res.status(status).json(result);
   }
   res.json(result);
+});
+
+// ── Webhooks (CRUD) ──
+
+router.get('/api/webhooks', requireAuth, (_req, res) => {
+  const result = listWebhooks();
+  if (!result.ok) return res.status(500).json(result);
+  res.json(result);
+});
+
+router.get('/api/webhooks/:id', requireAuth, (req: Request<{id: string}>, res: Response) => {
+  const result = getWebhookById(req.params.id);
+  if (!result.ok) {
+    const status = result.error.code === 'NOT_FOUND' ? 404 : 500;
+    return res.status(status).json(result);
+  }
+  res.json(result);
+});
+
+router.post('/api/webhooks', requireAuth, (req: Request, res: Response) => {
+  const CreateWebhookSchema = WebhookSchema.omit({ id: true, createdAt: true });
+  const parsed = CreateWebhookSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: { code: 'VALIDATION', message: parsed.error.message } });
+  }
+
+  const result = createWebhook(parsed.data.url, parsed.data.events, parsed.data.secret);
+  if (!result.ok) return res.status(500).json(result);
+  res.status(201).json(result);
+});
+
+router.delete('/api/webhooks/:id', requireAuth, (req: Request<{id: string}>, res: Response) => {
+  const result = deleteWebhook(req.params.id);
+  if (!result.ok) {
+    const status = result.error.code === 'NOT_FOUND' ? 404 : 500;
+    return res.status(status).json(result);
+  }
+  res.json(result);
+});
+
+// ── Tags ──
+
+router.get('/api/tags', (_req, res) => {
+  const result = listTags();
+  if (!result.ok) return res.status(500).json(result);
+  res.json(result);
+});
+
+router.post('/api/tags', requireAuth, (req: Request, res: Response) => {
+  const { name, color } = req.body;
+  if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    return res.status(400).json({ ok: false, error: { code: 'VALIDATION', message: 'name is required' } });
+  }
+  if (color && !/^#[0-9a-fA-F]{6}$/.test(color)) {
+    return res.status(400).json({ ok: false, error: { code: 'VALIDATION', message: 'color must be a hex color (e.g. #ff0000)' } });
+  }
+
+  const result = createTag(name.trim(), color);
+  if (!result.ok) {
+    const status = result.error.code === 'DUPLICATE' ? 409 : 500;
+    return res.status(status).json(result);
+  }
+  res.status(201).json(result);
+});
+
+router.delete('/api/tags/:id', requireAuth, (req: Request<{id: string}>, res: Response) => {
+  const result = deleteTag(req.params.id);
+  if (!result.ok) {
+    const status = result.error.code === 'NOT_FOUND' ? 404 : 500;
+    return res.status(status).json(result);
+  }
+  res.json({ ok: true, data: { deleted: true } });
+});
+
+router.get('/api/services/:id/tags', (req, res) => {
+  const result = getTagsForService(req.params.id);
+  if (!result.ok) return res.status(500).json(result);
+  res.json(result);
+});
+
+router.post('/api/services/:id/tags', requireAuth, (req: Request<{id: string}>, res: Response) => {
+  const { tagId } = req.body;
+  if (!tagId) {
+    return res.status(400).json({ ok: false, error: { code: 'VALIDATION', message: 'tagId is required' } });
+  }
+  const result = addTagToService(req.params.id, tagId);
+  if (!result.ok) {
+    const status = result.error.code === 'DUPLICATE' ? 409
+      : result.error.code === 'NOT_FOUND' ? 404
+      : 500;
+    return res.status(status).json(result);
+  }
+  res.status(201).json(result);
+});
+
+router.delete('/api/services/:id/tags/:tagId', requireAuth, (req: Request<{id: string; tagId: string}>, res: Response) => {
+  const result = removeTagFromService(req.params.id, req.params.tagId);
+  if (!result.ok) {
+    const status = result.error.code === 'NOT_FOUND' ? 404 : 500;
+    return res.status(status).json(result);
+  }
+  res.json({ ok: true, data: { removed: true } });
+});
+
+// Tag-based service filtering
+router.get('/api/tags/filter', (req, res) => {
+  const tagIds = (req.query.tagIds as string || '').split(',').filter(Boolean);
+  const mode = (req.query.mode as string) === 'and' ? 'and' as const : 'or' as const;
+
+  if (tagIds.length === 0) {
+    return res.status(400).json({ ok: false, error: { code: 'VALIDATION', message: 'tagIds query parameter is required' } });
+  }
+
+  const result = getServicesByTag(tagIds, mode);
+  if (!result.ok) return res.status(500).json(result);
+  res.json(result);
+});
+
+// ── Composite Services ──
+
+router.post('/api/composite-services', requireAuth, (req: Request, res: Response) => {
+  const { name, childIds, derivationRule } = req.body;
+  if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    return res.status(400).json({ ok: false, error: { code: 'VALIDATION', message: 'name is required' } });
+  }
+
+  const result = createCompositeService(name.trim(), childIds || [], derivationRule || 'worst-case');
+  if (!result.ok) {
+    const status = result.error.code === 'VALIDATION' || result.error.code === 'NOT_FOUND' ? 400 : 500;
+    return res.status(status).json(result);
+  }
+  recordAudit('service.create', 'service', result.data.id, { detail: `Composite: ${result.data.name}` });
+  res.status(201).json(result);
+});
+
+router.get('/api/composite-services/:id/children', (req, res) => {
+  const result = getChildren(req.params.id);
+  if (!result.ok) return res.status(500).json(result);
+  res.json(result);
+});
+
+router.post('/api/composite-services/:id/children', requireAuth, (req: Request<{id: string}>, res: Response) => {
+  const { childId, weight } = req.body;
+  if (!childId) {
+    return res.status(400).json({ ok: false, error: { code: 'VALIDATION', message: 'childId is required' } });
+  }
+
+  const result = addChild(req.params.id, childId, weight);
+  if (!result.ok) {
+    const status = result.error.code === 'VALIDATION' || result.error.code === 'DUPLICATE' ? 400
+      : result.error.code === 'NOT_FOUND' ? 404
+      : 500;
+    return res.status(status).json(result);
+  }
+  res.status(201).json(result);
+});
+
+router.delete('/api/composite-services/:id/children/:childId', requireAuth, (req: Request<{id: string; childId: string}>, res: Response) => {
+  const result = removeChild(req.params.id, req.params.childId);
+  if (!result.ok) {
+    const status = result.error.code === 'NOT_FOUND' ? 404 : 500;
+    return res.status(status).json(result);
+  }
+  res.json(result);
+});
+
+router.post('/api/composite-services/:id/compute', (req, res) => {
+  const result = computeStatus(req.params.id);
+  if (!result.ok) {
+    const status = result.error.code === 'NOT_FOUND' ? 404 : 500;
+    return res.status(status).json(result);
+  }
+  res.json({ ok: true, data: { status: result.data } });
+});
+
+// ── Cache Stats ──
+
+router.get('/api/cache/stats', requireAuth, (_req, res) => {
+  const stats = getCacheStats();
+  res.json({ ok: true, data: stats });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,8 +12,11 @@ import { startScheduler, stopScheduler } from './monitors/index.js';
 import { startDailyAggregator, stopDailyAggregator } from './monitors/daily-aggregator.js';
 import { startPercentileAggregator, stopPercentileAggregator } from './monitors/percentile-aggregator.js';
 import { startReportScheduler, stopReportScheduler } from './reports/index.js';
+import { startMaintenanceNotifier, stopMaintenanceNotifier } from './maintenance/notification-scheduler.js';
 import { router } from './api/routes.js';
 import { themeRouter } from './api/theme-config.js';
+import { bulkRouter } from './api/bulk-operations.js';
+import { cacheMiddleware } from './api/cache-middleware.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const config = loadConfig();
@@ -33,9 +36,13 @@ app.get('/', (_req, res) => {
   res.sendFile(path.join(__dirname, 'status-page', 'index.html'));
 });
 
+// HTTP response caching middleware for GET API endpoints
+app.use('/api', cacheMiddleware());
+
 // API routes
 app.use(router);
 app.use(themeRouter);
+app.use(bulkRouter);
 
 // Health endpoint
 app.get('/health', (_req, res) => {
@@ -45,11 +52,12 @@ app.get('/health', (_req, res) => {
 // Initialize database
 getDb();
 
-// Start monitoring scheduler and daily aggregator
+// Start monitoring scheduler and background workers
 startScheduler();
 startDailyAggregator();
 startPercentileAggregator();
 startReportScheduler();
+startMaintenanceNotifier();
 
 const server = app.listen(config.port, config.host, () => {
   log.info({ port: config.port, host: config.host }, 'StatusOwl server started');
@@ -62,6 +70,7 @@ function shutdown() {
   stopDailyAggregator();
   stopPercentileAggregator();
   stopReportScheduler();
+  stopMaintenanceNotifier();
   server.close();
   closeDb();
   process.exit(0);


### PR DESCRIPTION
## Summary

- **Tag routes** — GET/POST/DELETE `/api/tags`, service-tag associations at `/api/services/:id/tags`, tag-based filtering at `/api/tags/filter`
- **Bulk operations router** — Mounted `bulkRouter` in server.ts for `/api/bulk/services/{create,update,delete}`
- **Composite service routes** — CRUD at `/api/composite-services`, child management, status computation
- **Cache middleware** — Applied `cacheMiddleware()` to `/api` routes for ETag/Last-Modified/304 responses, added `/api/cache/stats`
- **Maintenance notification scheduler** — `startMaintenanceNotifier()`/`stopMaintenanceNotifier()` in server lifecycle
- **Webhook CRUD routes** — GET/POST/DELETE `/api/webhooks`

## Root Cause

v0.7.0 agent fleet implemented 6 features with full test coverage (228 tests) but never registered the routes in `routes.ts` or the middleware/schedulers in `server.ts`. Tests passed because they test modules directly, not via HTTP.

## Test Plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm test` — 834/834 tests passing
- [x] Runtime verification: started server, exercised every new endpoint via curl
- [x] ETag caching verified: first request returns `X-Cache: MISS`, conditional request returns `304 Not Modified`
- [x] Maintenance notifier log: "Starting maintenance notification scheduler"

Closes #81, #82, #83, #84, #85, #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)